### PR TITLE
renamed misleading field name / es5 compatibility for pagination

### DIFF
--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -160,7 +160,7 @@
                        ops-with-size)]
     (reverse (map second groups))))
 
-(defn- bulk-post-docs
+(defn ^:private bulk-post-docs
   [json-ops
    {:keys [uri cm] :as _conn}
    opts]
@@ -306,21 +306,23 @@
     index-name :- s/Str]
    (count-docs es-conn index-name nil)))
 
-(defn- result-data
+(defn ^:private result-data
   [res full-hits?]
   (cond->> (-> res :hits :hits)
     (not full-hits?) (map :_source)))
 
-(defn- pagination-params
+(defn ^:private pagination-params
   [{:keys [hits]}
    {:keys [from size search_after]}]
   {:offset from
    :limit size
    :sort (-> hits :hits last :sort)
    :search_after search_after
-   :hits (get-in hits [:total :value] 0)})
+   :total-hits (or (get-in hits [:total :value])
+                   (:total hits) ;; compatibility with 5.x
+                   0)})
 
-(defn- format-result
+(defn ^:private format-result
   [{:keys [aggregations] :as res}
    es-params
    full-hits?]

--- a/src/ductile/pagination.clj
+++ b/src/ductile/pagination.clj
@@ -19,7 +19,7 @@
            limit
            sort
            search_after
-           hits]}]
+           total-hits]}]
   (let [offset (or offset 0)
         limit (or limit default-limit)
         previous-offset (- offset limit)
@@ -29,7 +29,7 @@
                        (> max-result-window (+ offset limit)))
         next? (if search_after
                 (= limit (count results))
-                (> hits next-offset))
+                (> total-hits next-offset))
         previous {:previous {:limit limit
                              :offset (if (> previous-offset 0)
                                        previous-offset 0)}}
@@ -40,7 +40,7 @@
                 sort (assoc :search_after sort))}]
     {:data results
      :paging (merge
-              {:total-hits hits}
+              {:total-hits total-hits}
               (when previous? previous)
               (when next? next)
               (when sort {:sort sort}))}))

--- a/test/ductile/pagination_test.clj
+++ b/test/ductile/pagination_test.clj
@@ -8,13 +8,13 @@
     (is (= {:data results
             :paging {:total-hits 100}}
            (sut/response results
-                         {:hits 100}))
+                         {:total-hits 100}))
         "total-hits must be returned in the response")
     (is (= {:data results
             :paging {:total-hits 100
                      :sort [5 "value2"]}}
             (sut/response results
-                          {:hits 100
+                          {:total-hits 100
                            :sort [5 "value2"]}))
         "sort values must be passed as result")
     (testing "search_after, next and previous fields should be properly for paginating"
@@ -25,7 +25,7 @@
                        :next {:limit 10
                               :offset 90}}}
              (sut/response results
-                           {:hits 100
+                           {:total-hits 100
                             :limit 10
                             :offset 80})))
       (is (= {:data results
@@ -33,7 +33,7 @@
                        :previous {:limit 10
                                   :offset 80}}}
              (sut/response results
-                           {:hits 100
+                           {:total-hits 100
                             :limit 10
                             :offset 90})))
       (is (= {:data results
@@ -41,7 +41,7 @@
                        :next {:limit 10
                               :offset 10}}}
              (sut/response results
-                           {:hits 100
+                           {:total-hits 100
                             :limit 10})))
       (is (= {:data results
               :paging {:total-hits 100
@@ -50,7 +50,7 @@
                               :search_after [5 "value2"]}
                        :sort [5 "value2"]}}
              (sut/response results
-                           {:hits 100
+                           {:total-hits 100
                             :limit 10
                             :offset 10
                             :sort [5 "value2"]
@@ -58,6 +58,6 @@
       (is (= {:data (take 3 results)
               :paging {:total-hits 100}}
              (sut/response (take 3 results)
-                           {:hits 100
+                           {:total-hits 100
                             :limit 10
                             :search_after [4 "value1"]}))))))


### PR DESCRIPTION
> related #threatgrid/iroh/issues/4215

This PR proposes a fail over compatibility between ES5 and ES7 format for rendering total hits on a `_search` query.
It enables me to easily migrate pagination from clj-momo to ductile in CTIA for https://github.com/threatgrid/ctia/pull/991
In addition it also rename a field in the pagination results, the former one was misleading since `hits.hits` refers to the matched documents in ES.