### PR TITLE
Es5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - chmod +x $COMPOSE_BIN 
 
 before_script:
-    - $COMPOSE_BIN -f containers/es7/docker-compose.yml up -d > $COMPOSE_LOG
+    - $COMPOSE_BIN -f containers/docker-compose.yml up -d > $COMPOSE_LOG
     # Wait ES
     - until curl http://127.0.0.1:9200/; do sleep 1; done
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ before_install:
 before_script:
     - $COMPOSE_BIN -f containers/docker-compose.yml up -d > $COMPOSE_LOG
     # Wait ES
-    - until curl http://127.0.0.1:9200/; do sleep 1; done
+    - until curl http://127.0.0.1:9205/; do sleep 1; done
+    - until curl http://127.0.0.1:9207/; do sleep 1; done
 
 services:
     - docker 

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -3,14 +3,15 @@ services:
   es5:
     image: elasticsearch:5.6.9
     environment:
-      - cluster.name=elasticsearch7
+      - cluster.name=elasticsearch5
+      - discovery.type=single-node
     ports:
       - "9205:9200"
       - "9305:9300"
   es7:
     image: elasticsearch:7.9.2
     environment:
-      - cluster.name=elasticsearch
+      - cluster.name=elasticsearch7
       - discovery.type=single-node
     ports:
       - "9207:9200"

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  es5:
+    image: elasticsearch:5.6.9
+    environment:
+      - cluster.name=elasticsearch7
+    ports:
+      - "9205:9200"
+      - "9305:9300"
+  es7:
+    image: elasticsearch:7.5.2
+    environment:
+      - cluster.name=elasticsearch
+      - discovery.type=single-node
+    ports:
+      - "9207:9200"
+      - "9307:9300"

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "9205:9200"
       - "9305:9300"
   es7:
-    image: elasticsearch:7.5.2
+    image: elasticsearch:7.9.2
     environment:
       - cluster.name=elasticsearch
       - discovery.type=single-node

--- a/containers/es5/docker-compose.yml
+++ b/containers/es5/docker-compose.yml
@@ -1,7 +1,7 @@
 elasticsearch-dev:
   image: elasticsearch:5.6.9
   environment:
-    - cluster.name=elasticsearch
+    - cluster.name=elasticsearch5
   ports:
-    - "9200:9200"
-    - "9300:9300"
+    - "9205:9200"
+    - "9305:9300"

--- a/containers/es7/docker-compose.yml
+++ b/containers/es7/docker-compose.yml
@@ -4,5 +4,5 @@ elasticsearch-dev:
     - cluster.name=elasticsearch
     - discovery.type=single-node
   ports:
-    - "9200:9200"
-    - "9300:9300"
+    - "9207:9200"
+    - "9307:9300"

--- a/containers/es7/docker-compose.yml
+++ b/containers/es7/docker-compose.yml
@@ -1,5 +1,5 @@
 elasticsearch-dev:
-  image: elasticsearch:7.5.2
+  image: elasticsearch:7.9.2
   environment:
     - cluster.name=elasticsearch
     - discovery.type=single-node

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  [metosin/schema-tools "0.12.2"]
                  [clj-http "3.10.1"]
                  [com.arohner/uri "0.1.2"]
-                 [cheshire "5.9.0"]]
+                 [cheshire "5.9.0"]
+                 [medley "1.3.0"]]
   :repositories [["sonatype-snapshots" {:url "https://oss.sonatype.org/content/repositories/snapshots/"}]]
   :main nil
   :codox {:output-path "doc"

--- a/src/ductile/conn.clj
+++ b/src/ductile/conn.clj
@@ -2,6 +2,7 @@
   (:require [clj-http.conn-mgr :refer [make-reusable-conn-manager]]
             [clojure.tools.logging :as log]
             [ductile.schemas :refer [ConnectParams ESConn]]
+            [medley.core :refer [assoc-some]]
             [schema.core :as s]))
 
 (def default-timeout 30000)
@@ -36,13 +37,14 @@
 
 (s/defn connect :- ESConn
   "instantiate an ES conn from props"
-  [{:keys [protocol host port timeout]
+  [{:keys [protocol host port timeout version]
     :or {protocol :http
          timeout default-timeout}} :- ConnectParams]
-
-  {:cm (make-connection-manager
-        (cm-options {:timeout timeout}))
-   :uri (format "%s://%s:%s" (name protocol) host port)})
+  (assoc-some
+   {:cm (make-connection-manager
+         (cm-options {:timeout timeout}))
+    :uri (format "%s://%s:%s" (name protocol) host port)}
+    :version version))
 
 (defn safe-es-read [{:keys [status body]
                      :as res}]

--- a/src/ductile/conn.clj
+++ b/src/ductile/conn.clj
@@ -1,5 +1,6 @@
 (ns ductile.conn
-  (:require [clj-http.conn-mgr :refer [make-reusable-conn-manager]]
+  (:require [clj-http.conn-mgr :refer [make-reusable-conn-manager
+                                       shutdown-manager]]
             [clojure.tools.logging :as log]
             [ductile.schemas :refer [ConnectParams ESConn]]
             [medley.core :refer [assoc-some]]
@@ -46,6 +47,9 @@
          (cm-options {:timeout timeout}))
     :uri (format "%s://%s:%s" (name protocol) host port)}
     :version version))
+
+(s/defn close [conn :- ESConn]
+  (-> conn :cm shutdown-manager))
 
 (defn safe-es-read [{:keys [status body]
                      :as res}]

--- a/src/ductile/conn.clj
+++ b/src/ductile/conn.clj
@@ -39,7 +39,8 @@
   "instantiate an ES conn from props"
   [{:keys [protocol host port timeout version]
     :or {protocol :http
-         timeout default-timeout}} :- ConnectParams]
+         timeout default-timeout
+         version 7}} :- ConnectParams]
   (assoc-some
    {:cm (make-connection-manager
          (cm-options {:timeout timeout}))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -91,7 +91,7 @@
 
 (s/defn get-doc
   "get a document on es and return only the source"
-  [{:keys [uri cm]} :- ESConn
+  [{:keys [uri cm version]} :- ESConn
    index-name :- s/Str
    id
    opts :- CRUDOptions]

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -257,15 +257,21 @@
 
 (s/defn delete-doc
   "delete a document on es, returns boolean"
-  [{:keys [uri cm]} :- ESConn
-   index-name :- s/Str
-   id :- s/Str
-   opts :- CRUDOptions]
-  (-> (client/delete (delete-doc-uri uri index-name id)
+  ([conn :- ESConn
+    index-name :- s/Str
+    id :- s/Str
+    opts :- CRUDOptions]
+   (delete-doc conn index-name nil id opts))
+  ([{:keys [uri cm]} :- ESConn
+    index-name :- s/Str
+    doc-type :- (s/maybe s/Str)
+    id :- s/Str
+    opts :- CRUDOptions]
+  (-> (client/delete (delete-doc-uri uri index-name doc-type id)
                      (conn/make-http-opts cm opts [:refresh]))
       conn/safe-es-read
       :result
-      (= "deleted")))
+      (= "deleted"))))
 
 (s/defn delete-by-query-uri
   [uri index-names]

--- a/src/ductile/index.clj
+++ b/src/ductile/index.clj
@@ -122,7 +122,7 @@
     index-patterns :- [s/Str]]
    (let [template (cond-> index-config
                     (<= 6 version) (assoc :index_patterns index-patterns)
-                    (= 5 version) (assoc :index_pattern (first index-patterns)))]
+                    (= 5 version) (assoc :template (first index-patterns)))]
     (safe-es-read
      (client/put (template-uri uri template-name)
                  (make-http-opts cm {} nil template nil)))))

--- a/src/ductile/index.clj
+++ b/src/ductile/index.clj
@@ -121,8 +121,8 @@
     index-config
     index-patterns :- [s/Str]]
    (let [template (cond-> index-config
-                    (<= 6 version) (assoc :index_patterns index-patterns)
-                    (= 5 version) (assoc :template (first index-patterns)))]
+                    (>= version 6) (assoc :index_patterns index-patterns)
+                    (= version 5) (assoc :template (first index-patterns)))]
     (safe-es-read
      (client/put (template-uri uri template-name)
                  (make-http-opts cm {} nil template nil)))))

--- a/src/ductile/schemas.clj
+++ b/src/ductile/schemas.clj
@@ -10,6 +10,7 @@
    {:host s/Str
     :port s/Int
     (s/optional-key :protocol) (s/enum :http :https)
+    (s/optional-key :version) s/Int
     (s/optional-key :timeout) s/Int}))
 
 (s/defschema ESConn

--- a/src/ductile/schemas.clj
+++ b/src/ductile/schemas.clj
@@ -19,7 +19,7 @@
   {:cm (s/either PoolingClientConnectionManager
                  PoolingHttpClientConnectionManager)
    :uri s/Str
-   (s/optional-key :version) s/Int})
+   :version s/Int})
 
 (s/defschema Refresh
   "ES refresh parameter, see

--- a/src/ductile/schemas.clj
+++ b/src/ductile/schemas.clj
@@ -17,7 +17,8 @@
    connection manager and an index name"
   {:cm (s/either PoolingClientConnectionManager
                  PoolingHttpClientConnectionManager)
-   :uri s/Str})
+   :uri s/Str
+   (s/optional-key :version) s/Int})
 
 (s/defschema Refresh
   "ES refresh parameter, see

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -126,29 +126,41 @@
            (sut/generate-search-params nil aggs {:limit 0}))
         "generate-search-params should set :aggs with aggs passed as parameter")))
 
-(defn test-document-crud-ops
-  [{:keys [version] :as conn}]
-  )
+(deftest partition-json-ops-test
+  (is (= [["ops1"] ["ops2"] ["ops3--"]]
+         (sut/partition-json-ops
+          ["ops1" "ops2" "ops3--"]
+          1))
+      "All elements are in a group if the max size is exceeded")
+  (is (= [["ops1" "ops2"] ["ops3--"]]
+         (sut/partition-json-ops
+          ["ops1" "ops2" "ops3--"]
+          8))
+      "The max size is used to partition ops")
+  (is (= [["ops1" "ops2" "ops3--"]]
+         (sut/partition-json-ops
+          ["ops1" "ops2" "ops3--"]
+          1000))
+      "All ops are in the same group"))
 
 (def conn-es5 (es-conn/connect {:host "localhost" :port 9205 :version 5}))
 (def conn-es7 (es-conn/connect {:host "localhost" :port 9207 :version 7}))
 
 (deftest ^:integration document-crud-ops
   (doseq [{:keys [version]:as conn} [conn-es5 conn-es7]]
-    (assert version "this test relies on the version to make the appropriate function call")
     (testing (format "all ES Document CRUD operations, ES version %s"  (:version conn))
       (es-index/delete! conn "test_index")
       (let [sample-doc {:id "test_doc"
                         :foo "bar is a lie"
                         :test_value 42}
-            doc-type (if (<= version 5) "test-type" "_doc")
+            doc-type (if (= version 5) "test-type" "_doc")
             sample-docs
             (repeatedly 10 #(cond-> (hash-map :id (.toString (java.util.UUID/randomUUID))
                                               :_index "test_index"
                                               :bar "foo")
-                              (<= 5 version) (assoc :_type doc-type)))
+                              (= 5 version) (assoc :_type doc-type)))
             get-doc (fn [doc-id opts]
-                      (if (< 5 version)
+                      (if (= 5 version)
                         (sut/get-doc conn "test_index" doc-id opts)
                         (sut/get-doc conn "test_index" doc-type doc-id opts)))
             get-sample-doc #(get-doc (:id sample-doc) {})
@@ -162,6 +174,11 @@
                          (if (< 5 version)
                            (sut/index-doc conn "test_index" doc opts)
                            (sut/index-doc conn "test_index" doc-type doc opts)))
+
+            delete-doc (fn [doc-id opts]
+                         (if (< 5 version)
+                           (sut/delete-doc conn "test_index" doc-id opts)
+                           (sut/delete-doc conn "test_index" doc-type doc-id opts)))
 
             update-doc (fn [doc-id doc opts]
                          (if (< 5 version)
@@ -230,286 +247,278 @@
               ;; restore with the initial values
               (index-doc sample-doc
                          {:refresh "true"}))))
-        ;;    (testing "bulk-create-doc"
-        ;;      (is (= sample-docs
-        ;;             (sut/bulk-create-doc conn
-        ;;                                  sample-docs
-        ;;                                  {:refresh "true"})))
-        ;;      (testing "with partioning"
-        ;;        (let [sample-docs-2 (map #(assoc % :test_value 43) sample-docs)]
-        ;;          (is (= sample-docs-2
-        ;;                 (sut/bulk-create-doc conn
-        ;;                                      sample-docs-2
-        ;;                                      {:refresh "true"}
-        ;;                                      0)))
-        ;;          (is (= 10
-        ;;                 (get-in (sut/search-docs conn
-        ;;                                          "test_index"
-        ;;                                          {:query_string {:query "*"}}
-        ;;                                          {:test_value 43}
-        ;;                                          {:sort_by "test_value"
-        ;;                                           :sort_order :desc})
-        ;;                         [:paging :total-hits]))))))
-        ;;    (is (= {:data #{sample-doc (dissoc sample-doc :id)}
-        ;;            :paging {:total-hits 2
-        ;;                     :sort [42]}}
-        ;;           (update
-        ;;            (sut/search-docs conn
-        ;;                             "test_index"
-        ;;                             {:query_string {:query "bar"}}
-        ;;                             {:test_value 42}
-        ;;                             {:sort_by "test_value"
-        ;;                              :sort_order :desc})
-        ;;            :data set)
-        ;;           (update
-        ;;            (sut/search-docs conn
-        ;;                             "test_index"
-        ;;                             {:query_string {:query "bar"}}
-        ;;                             {:test_value 42}
-        ;;                             {:sort_by "test_value"
-        ;;                              :sort_order :desc})
-        ;;            :data set)))
-        ;;    (is (true?
-        ;;         (sut/delete-doc conn
-        ;;                         "test_index"
-        ;;                         (:id sample-doc)
-        ;;                         {:refresh "true"})))
-        ))
+        (testing "bulk-create-doc"
+          (is (= sample-docs
+                 (sut/bulk-create-doc conn
+                                      sample-docs
+                                      {:refresh "true"})))
+          (testing "with partioning"
+            (let [sample-docs-2 (map #(assoc % :test_value 43) sample-docs)]
+              (is (= sample-docs-2
+                     (sut/bulk-create-doc conn
+                                          sample-docs-2
+                                          {:refresh "true"}
+                                          0)))
+              (is (= 10
+                     (get-in (sut/search-docs conn
+                                              "test_index"
+                                              {:query_string {:query "*"}}
+                                              {:test_value 43}
+                                              {:sort_by "test_value"
+                                               :sort_order :desc})
+                             [:paging :total-hits]))))))
+        (is (= {:data #{sample-doc (dissoc sample-doc :id)}
+                :paging {:total-hits 2
+                         :sort [42]}}
+               (update
+                (sut/search-docs conn
+                                 "test_index"
+                                 {:query_string {:query "bar"}}
+                                 {:test_value 42}
+                                 {:sort_by "test_value"
+                                  :sort_order :desc})
+                :data set)
+               (update
+                (sut/search-docs conn
+                                 "test_index"
+                                 {:query_string {:query "bar"}}
+                                 {:test_value 42}
+                                 {:sort_by "test_value"
+                                  :sort_order :desc})
+                :data set)))
+            (is (true?
+                 (delete-doc (:id sample-doc) {:refresh "true"})))))
     (es-index/delete! conn "test_index")))
-
-(deftest partition-json-ops-test
-(is (= [["ops1"] ["ops2"] ["ops3--"]]
-       (sut/partition-json-ops
-        ["ops1" "ops2" "ops3--"]
-        1))
-    "All elements are in a group if the max size is exceeded")
-(is (= [["ops1" "ops2"] ["ops3--"]]
-       (sut/partition-json-ops
-        ["ops1" "ops2" "ops3--"]
-        8))
-    "The max size is used to partition ops")
-(is (= [["ops1" "ops2" "ops3--"]]
-       (sut/partition-json-ops
-        ["ops1" "ops2" "ops3--"]
-        1000))
-    "All ops are in the same group"))
 
 (deftest ^:integration search_after-consistency-test
-(let [docs
-      (let [make-id #(.toString (java.util.UUID/randomUUID))]
-        (map
-         #(hash-map :id (make-id)
-                    :foo %
-                    :test "ok")
-         (range 1000)))
-      conn (es-conn/connect {:host "localhost" :port 9207})
-      search-query #(get-in (sut/search-docs conn
-                                             "test_index"
-                                             nil
-                                             {}
-                                             {:limit 100})
-                            [:paging :sort])]
-  (es-index/delete! conn "test_index")
-  (es-index/create! conn "test_index" {})
-  (doseq [doc docs]
-    (sut/create-doc conn
-                    "test_index"
-                    doc
-                    {:refresh "true"}))
-  (is (apply = (repeatedly 30 search-query)))
-  (es-index/delete! conn "test_index")))
+  (doseq [{:keys [version]:as conn} [conn-es5 conn-es7]]
+    (testing (format "Search_after must enable consitent pagination for ES version %s"  (:version conn))
+      (let [docs
+            (let [make-id #(.toString (java.util.UUID/randomUUID))]
+              (map
+               #(hash-map :id (make-id)
+                          :foo %
+                          :test "ok")
+               (range 1000)))
+            search-query #(get-in (sut/search-docs conn
+                                                   "test_index"
+                                                   nil
+                                                   {}
+                                                   {:limit 100})
+                                  [:paging :sort])]
+        (es-index/delete! conn "test_index")
+        (es-index/create! conn "test_index" {})
+        (doseq [doc docs]
+          (if (= version 5)
+            (sut/create-doc conn
+                            "test_index"
+                            "doc-type"
+                            doc
+                            {:refresh "true"})
+            (sut/create-doc conn
+                            "test_index"
+                            doc
+                            {:refresh "true"})))
+        (is (apply = (repeatedly 30 search-query)))
+        (es-index/delete! conn "test_index")))))
 
 (deftest ^:integration count-test
-(let [sample-docs (mapv #(assoc {:_index "test_index"
-                                 :foo :bar}
-                                :_id %)
-                        (range 10))
-      conn (es-conn/connect {:host "localhost" :port 9207})]
-  (es-index/delete! conn "test_index")
-  (es-index/create! conn "test_index" {})
-  (sut/bulk-create-doc conn
-                       sample-docs
-                       {:refresh "true"})
-  (is (= 10
-         (sut/count-docs conn "test_index")
-         (sut/count-docs conn "test_index")
-         (sut/count-docs conn "test_index" {:term {:foo :bar}})
-         (sut/count-docs conn "test_index" {:match_all {}})))
-  (is (= 3 (sut/count-docs conn "test_index" {:ids {:values (range 3)}})))
-  (es-index/delete! conn "test_index")))
+  (doseq [{:keys [version]:as conn} [conn-es5 conn-es7]]
+    (testing (format "count-docs must properly count document for ES version %s"  (:version conn))
+      (let [sample-docs (mapv #(cond-> {:_index "test_index"
+                                        :foo :bar
+                                        :_id %}
+                                 (= 5 version) (assoc :_type "doc-type"))
+                              (range 10))]
+        (es-index/delete! conn "test_index")
+        (es-index/create! conn "test_index" {})
+        (sut/bulk-create-doc conn
+                             sample-docs
+                             {:refresh "true"})
+        (is (= 10
+               (sut/count-docs conn "test_index")
+               (sut/count-docs conn "test_index")
+               (sut/count-docs conn "test_index" {:term {:foo :bar}})
+               (sut/count-docs conn "test_index" {:match_all {}})))
+        (is (= 3 (sut/count-docs conn "test_index" {:ids {:values (range 3)}})))
+        (es-index/delete! conn "test_index")))))
 
 (defn is-full-hits?
-[{:keys [_source _index _id]}]
-(boolean (and _source _index _id)))
+  [{:keys [_source _index _id]}]
+  (boolean (and _source _index _id)))
 
 (deftest ^:integration query-test
-(let [sample-docs (mapv #(assoc {:_index "test_index"
-                                 :foo :bar
-                                 :price %}
-                                :_id (str %))
-                        (range 10))
-      conn (es-conn/connect {:host "localhost" :port 9207})
-      sample-3-docs (->> (shuffle sample-docs)
-                         (take 3))
-      sample-3-ids (map :_id sample-3-docs)
-      _ (es-index/delete! conn "test_index")
-      _ (es-index/create! conn "test_index" {})
-      _ (sut/bulk-create-doc conn sample-docs {:refresh "true"})
-      ids-query-result-1 (sut/query conn
+  (doseq [{:keys [version]:as conn} [conn-es5 conn-es7]]
+    (testing (format "query should tigger a proper search query for ES version %s"  (:version conn))
+      (let [sample-docs (mapv #(cond-> {:_index "test_index"
+                                        :foo :bar
+                                        :price %
+                                        :_id (str %)}
+                                 (= 5 version) (assoc :_type "doc-type"))
+                              (range 10))
+            sample-3-docs (->> (shuffle sample-docs)
+                               (take 3))
+            sample-3-ids (map :_id sample-3-docs)
+            _ (es-index/delete! conn "test_index")
+            _ (es-index/create! conn "test_index" {})
+            _ (sut/bulk-create-doc conn sample-docs {:refresh "true"})
+            ids-query-result-1 (sut/query conn
+                                          "test_index"
+                                          (query/ids sample-3-ids)
+                                          {})
+            ids-query-result-2 (sut/query conn
+                                          "test_index"
+                                          (query/ids sample-3-ids)
+                                          {:full-hits? true})
+            search_after-result (sut/query conn
+                                           "test_index"
+                                           {:match_all {}}
+                                           {:limit 2
+                                            :sort ["price"]
+                                            :search_after [5]})
+            avg-aggs {:avg_price {:avg {:field :price}}}
+            {data-aggs-1 :data
+             aggs-1 :aggs
+             paging-aggs-1 :paging} (sut/query conn
+                                               "test_index"
+                                               {:match_all {}}
+                                               avg-aggs
+                                               {:limit 5})
+
+            stats-aggs {:price_stats {:stats {:field :price}}}
+            {data-aggs-2 :data
+             aggs-2 :aggs} (sut/query conn
+                                      "test_index"
+                                      {:match_all {}}
+                                      stats-aggs
+                                      {:limit 0})
+            stats-aggs {:price_stats {:stats {:field :price}}}
+            {data-aggs-3 :data
+             aggs-3 :aggs} (sut/query conn
+                                      "test_index"
+                                      (query/ids (map :_id (take 3 sample-docs)))
+                                      stats-aggs
+                                      {:limit 10})]
+
+        (is (= (repeat 3 {:foo "bar"})
+               (->> ids-query-result-1
+                    :data
+                    (map #(select-keys % [:foo]))))
+            "querying with ids query without full-hits? param should return only source of selected docs in :data")
+        (testing "when full-hits is set as true, each element of :data field should contains :_id :_source and :_index fields"
+          (is (= (set sample-3-ids)
+                 (->> (:data ids-query-result-2)
+                      (map :_id)
+                      set)))
+          (is (= (repeat 3 "bar")
+                 (->> (:data ids-query-result-2)
+                      (map #(-> % :_source :foo)))))
+          (is (= (repeat 3 "test_index")
+                 (->> (:data ids-query-result-2)
+                      (map :_index))))
+          (is (not-any? is-full-hits? (:data ids-query-result-1))
+              "by default, full-hits? is set to false"))
+        (testing "sort and search_after params should be properly applied"
+          (is (= '(6 7)
+                 (map :price (:data search_after-result))))
+          (is (= [7]
+                 (-> search_after-result :paging :sort)
+                 (-> search_after-result :paging :next :search_after))))
+        (when (<= 7 version)
+          (testing "track_total_hits should be properly considered"
+            (is (= 2 (-> (sut/query conn
                                     "test_index"
                                     (query/ids sample-3-ids)
-                                    {})
-      ids-query-result-2 (sut/query conn
+                                    {:track_total_hits 2})
+                         :paging
+                         :total-hits)))
+            (is (= 3
+                   (-> (sut/query conn
+                                  "test_index"
+                                  (query/ids sample-3-ids)
+                                  {:track_total_hits true})
+                       :paging
+                       :total-hits)
+                   (-> (sut/query conn
+                                  "test_index"
+                                  (query/ids sample-3-ids)
+                                  {})
+                       :paging
+                       :total-hits)))
+            (is (= 0 (-> (sut/query conn
                                     "test_index"
                                     (query/ids sample-3-ids)
-                                    {:full-hits? true})
-      search_after-result (sut/query conn
-                                     "test_index"
-                                     {:match_all {}}
-                                     {:limit 2
-                                      :sort ["price"]
-                                      :search_after [5]})
-      avg-aggs {:avg_price {:avg {:field :price}}}
-      {data-aggs-1 :data
-       aggs-1 :aggs
-       paging-aggs-1 :paging} (sut/query conn
-                                         "test_index"
-                                         {:match_all {}}
-                                         avg-aggs
-                                         {:limit 5})
-
-      stats-aggs {:price_stats {:stats {:field :price}}}
-      {data-aggs-2 :data
-       aggs-2 :aggs} (sut/query conn
-                                "test_index"
-                                {:match_all {}}
-                                stats-aggs
-                                {:limit 0})
-      stats-aggs {:price_stats {:stats {:field :price}}}
-      {data-aggs-3 :data
-       aggs-3 :aggs} (sut/query conn
-                                "test_index"
-                                (query/ids (map :_id (take 3 sample-docs)))
-                                stats-aggs
-                                {:limit 10})]
-
-  (is (= (repeat 3 {:foo "bar"})
-         (->> ids-query-result-1
-              :data
-              (map #(select-keys % [:foo]))))
-      "querying with ids query without full-hits? param should return only source of selected docs in :data")
-  (testing "when full-hits is set as true, each element of :data field should contains :_id :_source and :_index fields"
-    (is (= (set sample-3-ids)
-           (->> (:data ids-query-result-2)
-                (map :_id)
-                set)))
-    (is (= (repeat 3 "bar")
-           (->> (:data ids-query-result-2)
-                (map #(-> % :_source :foo)))))
-    (is (= (repeat 3 "test_index")
-           (->> (:data ids-query-result-2)
-                (map :_index))))
-    (is (not-any? is-full-hits? (:data ids-query-result-1))
-        "by default, full-hits? is set to false"))
-  (testing "track_total_hits should be properly considered"
-    (is (= 2 (-> (sut/query conn
-                            "test_index"
-                            (query/ids sample-3-ids)
-                            {:track_total_hits 2})
-                 :paging
-                 :total-hits)))
-    (is (= 3
-           (-> (sut/query conn
-                          "test_index"
-                          (query/ids sample-3-ids)
-                          {:track_total_hits true})
-               :paging
-               :total-hits)
-           (-> (sut/query conn
-                          "test_index"
-                          (query/ids sample-3-ids)
-                          {})
-               :paging
-               :total-hits)))
-    (is (= 0 (-> (sut/query conn
-                            "test_index"
-                            (query/ids sample-3-ids)
-                            {:track_total_hits false})
-                 :paging
-                 :total-hits))))
-  (testing "sort and search_after params should be properly applied"
-    (is (= '(6 7)
-           (map :price (:data search_after-result))))
-    (is (= [7]
-           (-> search_after-result :paging :sort)
-           (-> search_after-result :paging :next :search_after))))
-
-  (testing "aggs parameter should be used to perform aggregations, while applying query and paging"
-    (is (= 5 (count data-aggs-1)))
-    (is (= 4.5 (-> aggs-1 :avg_price :value)))
-    (is (= {:total-hits 10
-            :next {:limit 5 :offset 5}}
-           paging-aggs-1))
-    (is (= 0 (count data-aggs-2)))
-    (is (= {:count 10
-            :min 0.0
-            :max 9.0
-            :avg 4.5
-            :sum 45.0}
-           (:price_stats aggs-2)))
-    (is (= 3 (count data-aggs-3)))
-    (is (= {:count 3
-            :min 0.0
-            :max 2.0
-            :avg 1.0
-            :sum 3.0}
-           (:price_stats aggs-3))))
-  ;; clean
-  (es-index/delete! conn "test_index")))
+                                    {:track_total_hits false})
+                         :paging
+                         :total-hits)))))
+        (testing "aggs parameter should be used to perform aggregations, while applying query and paging"
+          (is (= 5 (count data-aggs-1)))
+          (is (= 4.5 (-> aggs-1 :avg_price :value)))
+          (is (= {:total-hits 10
+                  :next {:limit 5 :offset 5}}
+                 paging-aggs-1))
+          (is (= 0 (count data-aggs-2)))
+          (is (= {:count 10
+                  :min 0.0
+                  :max 9.0
+                  :avg 4.5
+                  :sum 45.0}
+                 (:price_stats aggs-2)))
+          (is (= 3 (count data-aggs-3)))
+          (is (= {:count 3
+                  :min 0.0
+                  :max 2.0
+                  :avg 1.0
+                  :sum 3.0}
+                 (:price_stats aggs-3))))
+        ;; clean
+        (es-index/delete! conn "test_index")))))
 
 (deftest ^:integration delete-by-query-test
-  (let [sample-docs-1 (mapv #(assoc {:_index "test_index-1"
-                                     :foo (if (< % 5)
-                                            :bar1
-                                            :bar2)}
-                                    :_id %)
-                            (range 10))
-        sample-docs-2 (mapv #(assoc {:_index "test_index-2"
-                                     :foo (if (< % 5)
-                                            :bar1
-                                            :bar2)}
-                                    :_id %)
-                            (range 10))
-        conn (es-conn/connect {:host "localhost" :port 9207})
-        q-term (query/term :foo :bar2)
-        q-ids-1 (query/ids ["0" "1" "2"])
-        q-ids-2 (query/ids ["3" "4"])]
-    (es-index/delete! conn "test_index")
-    (es-index/create! conn "test_index" {})
-    (sut/bulk-create-doc conn sample-docs-1 {:refresh "true"})
-    (sut/bulk-create-doc conn sample-docs-2 {:refresh "true"})
-    (is (= 5
-           (:deleted (sut/delete-by-query conn
-                                          ["test_index-1"]
-                                          q-term
-                                          {:wait_for_completion true
-                                           :refresh "true"})))
-        "delete-by-query should delete all documents that match a query for given index")
-    (is (= 6
-           (:deleted (sut/delete-by-query conn
-                                          ["test_index-1", "test_index-2"]
-                                          q-ids-1
-                                          {:wait_for_completion true
-                                           :refresh "true"})))
-        "delete-by-query should properly apply deletion on all given indices")
-    (is (seq (:task (sut/delete-by-query conn
-                                         ["test_index-1", "test_index-2"]
-                                         q-ids-2
-                                         {:wait_for_completion false
-                                          :refresh "true"})))
-        "delete-by-query with wait-for-completion? set to false should directly return an answer before deletion with a task id")
-    (es-index/delete! conn "test_index")))
-
+  (doseq [{:keys [version]:as conn} [conn-es5 conn-es7]]
+    (testing (format "delete-by-query should tigger a proper _delete_by_query request for ES version %s"  (:version conn))
+      (let [sample-docs-1 (mapv #(cond-> {:_index "test_index-1"
+                                          :foo (if (< % 5)
+                                                 :bar1
+                                                 :bar2)
+                                          :_id %}
+                                   (= 5 version) (assoc :_type "doc-type"))
+                                (range 10))
+            sample-docs-2 (mapv #(cond-> {:_index "test_index-2"
+                                          :foo (if (< % 5)
+                                                 :bar1
+                                                 :bar2)
+                                          :_id %}
+                                   (= 5 version) (assoc :_type "doc-type"))
+                                (range 10))
+            q-term (query/term :foo :bar2)
+            q-ids-1 (query/ids ["0" "1" "2"])
+            q-ids-2 (query/ids ["3" "4"])]
+        (es-index/delete! conn "test_index")
+        (es-index/create! conn "test_index" {})
+        (sut/bulk-create-doc conn sample-docs-1 {:refresh "true"})
+        (sut/bulk-create-doc conn sample-docs-2 {:refresh "true"})
+        (is (= 5
+               (:deleted (sut/delete-by-query conn
+                                              ["test_index-1"]
+                                              q-term
+                                              {:wait_for_completion true
+                                               :refresh "true"})))
+            "delete-by-query should delete all documents that match a query for given index")
+        (is (= 6
+               (:deleted (sut/delete-by-query conn
+                                              ["test_index-1", "test_index-2"]
+                                              q-ids-1
+                                              {:wait_for_completion true
+                                               :refresh "true"})))
+            "delete-by-query should properly apply deletion on all given indices")
+        (is (seq (:task (sut/delete-by-query conn
+                                             ["test_index-1", "test_index-2"]
+                                             q-ids-2
+                                             {:wait_for_completion false
+                                              :refresh "true"})))
+            "delete-by-query with wait-for-completion? set to false should directly return an answer before deletion with a task id")
+        (es-index/delete! conn "test_index")))))
 
 (deftest query-params-test
   (let [conn (es-conn/connect {:host "localhost" :port 9207})

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -56,6 +56,10 @@
   (is (= (sut/update-doc-uri "http://127.0.0.1"
                              "test-index"
                              "test-id")
+         (sut/update-doc-uri "http://127.0.0.1"
+                             "test-index"
+                             nil
+                             "test-id")
          "http://127.0.0.1/test-index/_update/test-id"))
   (is (= (sut/update-doc-uri "http://127.0.0.1"
                              "test-index"
@@ -153,35 +157,25 @@
                      :test_value 42}
          doc-type (if (= version 5) "test-type" "_doc")
          sample-docs
-         (repeatedly 10 #(cond-> (hash-map :id (.toString (java.util.UUID/randomUUID))
-                                           :_index "test_index"
-                                           :bar "foo")
-                           (= 5 version) (assoc :_type doc-type)))
+         (repeatedly 10 #(hash-map :id (.toString (java.util.UUID/randomUUID))
+                                   :_index "test_index"
+                                   :bar "foo"
+                                   :_type doc-type))
          get-doc (fn [doc-id opts]
-                   (if (< 5 version)
-                     (sut/get-doc conn "test_index" doc-id opts)
-                     (sut/get-doc conn "test_index" doc-type doc-id opts)))
+                   (sut/get-doc conn "test_index" doc-type doc-id opts))
          get-sample-doc #(get-doc (:id sample-doc) {})
 
          create-doc (fn [doc opts]
-                      (if (< 5 version)
-                        (sut/create-doc conn "test_index" doc opts)
-                        (sut/create-doc conn "test_index" doc-type doc opts)))
+                      (sut/create-doc conn "test_index" doc-type doc opts))
 
          index-doc (fn [doc opts]
-                     (if (< 5 version)
-                       (sut/index-doc conn "test_index" doc opts)
-                       (sut/index-doc conn "test_index" doc-type doc opts)))
+                     (sut/index-doc conn "test_index" doc-type doc opts))
 
          delete-doc (fn [doc-id opts]
-                      (if (< 5 version)
-                        (sut/delete-doc conn "test_index" doc-id opts)
-                        (sut/delete-doc conn "test_index" doc-type doc-id opts)))
+                      (sut/delete-doc conn "test_index" doc-type doc-id opts))
 
          update-doc (fn [doc-id doc opts]
-                      (if (< 5 version)
-                        (sut/update-doc conn "test_index" doc-id doc opts)
-                        (sut/update-doc conn "test_index" doc-type doc-id doc opts)))]
+                      (sut/update-doc conn "test_index" doc-type doc-id doc opts))]
      (testing "create-doc and get-doc"
        (is (nil? (get-sample-doc)))
        (is (= {:_id (-> sample-doc :id str)

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -17,19 +17,19 @@
   (testing "should generate a valid _search uri"
     (is (= "http://localhost:9200/ctia_tool/_search"
            (sut/search-uri "http://localhost:9200"
-                              "ctia_tool")))
+                           "ctia_tool")))
     (is (= "http://localhost:9200/_search"
            (sut/search-uri "http://localhost:9200"
-                              nil)))))
+                           nil)))))
 
 (deftest delete-by-query-uri-test
   (testing "should generate a valid delete_by_query uri"
     (is (= "http://localhost:9200/ctim/_delete_by_query"
            (sut/delete-by-query-uri "http://localhost:9200"
-                                       ["ctim"])))
+                                    ["ctim"])))
     (is (= "http://localhost:9200/ctim%2Cctia/_delete_by_query"
            (sut/delete-by-query-uri "http://localhost:9200"
-                                       ["ctim", "ctia"])))))
+                                    ["ctim", "ctia"])))))
 
 (deftest index-doc-uri-test
   (testing "should generate a valid doc URI"
@@ -73,7 +73,7 @@
           :sort {"field1" {:order :desc}}}
          (sut/params->pagination {:sort_by "field1:desc"})
          (sut/params->pagination {:sort_by "field1:desc"
-                                     :sort_order :asc})))
+                                  :sort_order :asc})))
 
   (is (= {:size 100
           :sort {"field1" {:order :desc}
@@ -81,20 +81,20 @@
                  "field3" {:order :desc}}}
          (sut/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"})
          (sut/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"
-                                     :sort_order :asc})))
+                                  :sort_order :asc})))
 
   (is (= {:size 100
           :from 1000
           :sort {"field1" {:order :asc}}}
          (sut/params->pagination {:sort_by :field1
-                                     :offset 1000})))
+                                  :offset 1000})))
 
   (is (= {:size 10000
           :from 1000
           :sort {"field1" {:order :asc}}}
          (sut/params->pagination {:sort_by :field1
-                                     :offset 1000
-                                     :limit 10000})))
+                                  :offset 1000
+                                  :limit 10000})))
 
   (is (= {:size 10000
           :from 0

--- a/test/ductile/index_test.clj
+++ b/test/ductile/index_test.clj
@@ -44,7 +44,7 @@
 (deftest ^:integration index-crud-ops
   (for-each-es-version
    "all ES Index CRUD operations"
-   (sut/delete! conn "test_index")
+   #(sut/delete! conn "test_index")
    (let [doc-type (when (= 5 version) :sighting)
          base-mappings (cond->> {:properties {:name {:type "text"}
                                               :age {:type "integer"}}}
@@ -97,7 +97,7 @@
 (deftest ^:integration rollover-test
   (for-each-es-version
    "rollover should properly trigger _rollover"
-   (sut/delete! conn "test_index-*")
+   #(sut/delete! conn "test_index-*")
    (sut/create! conn
                 "test_index-1"
                 {:settings {:number_of_shards 1
@@ -182,9 +182,9 @@
                             :refresh_interval "2s"}
                  :mappings (cond->> {:_source {:enabled false}}
                              (= version 5) (assoc {} doc-type))
-                             :aliases {:alias1 {}
-                                       :alias2 {:filter {:term {:user "kimchy"}}
-                                                :routing "kimchy"}}}
+                 :aliases {:alias1 {}
+                           :alias2 {:filter {:term {:user "kimchy"}}
+                                    :routing "kimchy"}}}
          _  (is (= {:acknowledged true}
                    (sut/create-template! conn
                                          template-name-1

--- a/test/ductile/test_helpers.clj
+++ b/test/ductile/test_helpers.clj
@@ -1,0 +1,16 @@
+(ns ductile.test-helpers
+  (:require [clojure.test :refer [testing]]
+            [ductile.conn :as es-conn]))
+
+(defmacro for-each-es-version [msg clean & body]
+  "for each version, init an ES connection, expose anaphora version and conn, and apply test body."
+  `(doseq [~'version [5 7]]
+     (let [~'conn (es-conn/connect {:host "localhost"
+                                    :port (+ 9200 ~'version)
+                                    :version ~'version})]
+       (testing (format "%s (ES version: %s)" ~msg  ~'version))
+       (if ~clean
+         '(~clean))
+       ~@body
+       (if ~clean
+         '(~clean)))))

--- a/test/ductile/test_helpers.clj
+++ b/test/ductile/test_helpers.clj
@@ -5,16 +5,20 @@
 (defmacro for-each-es-version [msg clean & body]
   "for each ES version:
 - init an ES connection
-- expose anaphoras `version` and `conn` to use in body
+- expose anaphoric `version` and `conn` to use in body
 - wrap body with a `testing` block with with `msg` formatted with `version`
 - call `clean` fn if not `nil` before and after body."
+  {:style/indent 2}
   `(doseq [~'version [5 7]]
      (let [~'conn (es-conn/connect {:host "localhost"
                                     :port (+ 9200 ~'version)
-                                    :version ~'version})]
-       (testing (format "%s (ES version: %s)" ~msg  ~'version))
-       (if ~clean
-         '(~clean))
-       ~@body
-       (if ~clean
-         '(~clean)))))
+                                    :version ~'version})
+           clean-fn# ~clean]
+       (try
+         (testing (format "%s (ES version: %s)" ~msg  ~'version)
+           (when clean-fn#
+             (clean-fn#))
+           ~@body
+           (when clean-fn#
+             (clean-fn#)))
+         (finally (es-conn/close ~'conn))))))

--- a/test/ductile/test_helpers.clj
+++ b/test/ductile/test_helpers.clj
@@ -3,7 +3,11 @@
             [ductile.conn :as es-conn]))
 
 (defmacro for-each-es-version [msg clean & body]
-  "for each version, init an ES connection, expose anaphora version and conn, and apply test body."
+  "for each ES version:
+- init an ES connection
+- expose anaphoras `version` and `conn` to use in body
+- wrap body with a `testing` block with with `msg` formatted with `version`
+- call `clean` fn if not `nil` before and after body."
   `(doseq [~'version [5 7]]
      (let [~'conn (es-conn/connect {:host "localhost"
                                     :port (+ 9200 ~'version)


### PR DESCRIPTION
> related #threatgrid/iroh/issues/4215

This PR provides a compatibility mode for ES5:

- [x] CRUD OPS
- [x] _update
- [x] _bulk
- [x] _delete_by_query
- [x] _search / query
- [x] index ops
- [x] index rollover
- [x] templates

I used a macro helper `for-each-version`, I recommend to first review this macro which provides `version` and `conn` anaphoras. I wrap all integration tests with this macro so I recommend to ignore whitespace changes for a better readability.