### PR TITLE
bulk update / delete

### DIFF
--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -187,7 +187,7 @@
     opts :- CRUDOptions]
    (bulk-create-docs conn docs opts nil))
   ([conn :- ESConn
-    docs :- [s/Any]
+    docs :- [(s/pred map?)]
     opts :- CRUDOptions
     max-size :- (s/maybe s/Int)]
    (bulk conn

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -45,7 +45,7 @@
                               "test_index"
                               ""
                               "test"))
-        "index-doc-uri should build an ES7 comptatible uri when the type is an empty string")
+        "index-doc-uri should buir an ES7 comptatible uri when the type is an empty string")
     (is (= "http://127.0.0.1/test-index/test-type/test-id"
            (sut/index-doc-uri "http://127.0.0.1"
                               "test-index"

--- a/test/ductile/index_test.clj
+++ b/test/ductile/index_test.clj
@@ -126,7 +126,7 @@
          "rollover dry_run paramater should be properly applied")
 
      ;; add 3 documents to trigger max-doc condition
-     (es-doc/bulk-create-doc conn
+     (es-doc/bulk-index-docs conn
                              (repeat 3 (cond-> {:_index aliasname
                                                 :foo :bar}
                                          (= 5 version) (assoc :_type "doc_type")))
@@ -236,7 +236,6 @@
      (doseq [indexname indices-names]
        (sut/create! conn indexname {}))
      (let [cat-res (sut/cat-indices conn)]
-       (clojure.pprint/pprint cat-res)
        (is (= (count indices-names)
               (count cat-res)))
        (is (= (set indices-names)


### PR DESCRIPTION
- refactor former `bulk-create-doc` into a generic bulk that accepts all ops operation
- add bulk helpers,`bulk-create-docs`, `bulk-create-docs`, `bulk-index-docs`, `bulk-delete-docs` and `bulk-update-docs` for applying a single action on a collection of documents.

FYI: here is the [ES Bulk doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html).