### PR TITLE
fix bulk result format

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def test-deps
   `[[ring/ring-codec ~ring-version]])
 
-(defproject threatgrid/ductile "0.3.0"
+(defproject threatgrid/ductile "0.4.0-SNAPSHOT"
   :description "Yet another Clojure client for Elasticsearch REST API, that fits our needs"
   :url "https://github.com/threatgrid/ductile"
   :license {:name "Eclipse Public License"

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -154,12 +154,9 @@
 
 (defn format-bulk-res
   [bulk-res-list]
-  (reduce (fn [res elem]
-            {:took (+ (:took res 0) (:took elem))
-             :errors (and (:errors res true) (:errors elem))
-             :items (concat (:items res) (:items elem))})
-          {}
-          bulk-res-list))
+  {:took (apply + (map :took bulk-res-list))
+   :errors (some? (some (comp true? :errors) bulk-res-list))
+   :items (mapcat :items bulk-res-list)})
 
 (s/defn bulk
   "Bulk actions on ES"


### PR DESCRIPTION
The bulk-ops are partitioned and submitted by batch. The result was then also returned as a partitioned list.
This PR modifies this behavior and returns a concatenated list of these batches.