### PR TITLE
fix large bulks

### DIFF
--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -8,7 +8,8 @@
             [ductile.query :as q]
             [ductile.schemas :refer [CRUDOptions ESAggs ESConn ESQuery]]
             [schema.core :as s]
-            [schema-tools.core :as st]))
+            [schema-tools.core :as st])
+  (:import java.io.ByteArrayInputStream))
 
 (def default-limit 1000)
 (def default-retry-on-conflict 5)
@@ -128,13 +129,20 @@
                        ops-with-size)]
     (reverse (map second groups))))
 
+(defn string->input-stream
+  [^String s]
+  (-> s
+      (.getBytes)
+      (ByteArrayInputStream.)))
+
 (defn ^:private bulk-post-docs
   [json-ops
    {:keys [uri request-fn] :as conn}
    opts]
   (let [bulk-body (-> json-ops
                       (interleave (repeat "\n"))
-                      string/join)]
+                      string/join
+                      string->input-stream)]
     (-> (conn/make-http-opts conn
                              opts
                              [:refresh]

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -345,7 +345,7 @@
      "all ES Document Bulk operations"
      #(es-index/delete! conn indexname)
      (let [doc-type (if (= version 5) "test-type" "_doc")
-           nb-sample-docs 100
+           nb-sample-docs 1000
            sample-docs (->> (repeatedly nb-sample-docs
                                         #(hash-map :id (str (UUID/randomUUID))
                                                    :_index indexname


### PR DESCRIPTION
#closes https://github.com/advthreat/iroh/issues/5385

Fix large bulks that can sometime fail (experienced it on first query of CTIA after start).
This PR replaces the string body by an input stream.
Many thanks @msprunck for helping and finding this solution!
