### PR TITLE
Update by query #iroh/5786

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,3 @@
+{:linters
+ {:unresolved-symbol
+  {:exclude [(ductile.test-helpers/for-each-es-version [version conn])]}}}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 .hgignore
 .hg/
 *.log
+.lsp/.cache/
+.clj-kondo/.cache/

--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,0 +1,2 @@
+{:linters
+ {:clj-kondo {}}}

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -429,12 +429,12 @@
   the source, which is useful for picking up mapping changes."
   [{:keys [uri request-fn] :as conn} :- ESConn
    index-names :- [s/Str]
-   form-params :- UpdateByQueryParams
+   form-params :- (s/maybe UpdateByQueryParams)
    opts :- CRUDOptions]
   (-> (conn/make-http-opts conn
                            opts
                            [:refresh :wait_for_completion :conflicts]
-                           form-params
+                           (or form-params {})
                            {})
       (assoc :method :post
              :url (update-by-query-uri uri index-names))

--- a/src/ductile/schemas.clj
+++ b/src/ductile/schemas.clj
@@ -107,3 +107,13 @@
      :rep s/Int
      :docs.count s/Int
      :docs.deleted s/Int})])
+
+(s/defschema ESScript
+  (st/optional-keys
+   {:source s/Str
+    :params {s/Str s/Any}}))
+
+(s/defschema UpdateByQueryParams
+  (st/optional-keys
+   {:script ESScript
+    :query  ESQuery}))

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -684,19 +684,18 @@
                      "the test index was not properly initialized")
 
            ;; insert some documents
-           sample-docs (map #(-> (hash-map :id (str (UUID/randomUUID))
+           sample-docs (map #(-> (hash-map :_index indexname
+                                           :_id (str (UUID/randomUUID))
+                                           :_type doc-type
                                            :name (str "name " %)
                                            :age %
                                            ;; one more field that's not indexed yet
                                            :sport "boxing"))
                             (range 20))
-           _ (doseq [doc sample-docs]
-               (sut/create-doc
-                conn
-                indexname
-                doc-type
-                doc
-                {:refresh "true"}))]
+           _ (sut/bulk-create-docs
+              conn
+              sample-docs
+              {:refresh "true"})]
        (testing "filter on a query and update with a script"
          (sut/update-by-query
           conn

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -23,14 +23,17 @@
            (sut/search-uri "http://localhost:9200"
                            nil)))))
 
-(deftest delete-by-query-uri-test
+(deftest x-by-query-uri-test
   (testing "should generate a valid delete_by_query uri"
     (is (= "http://localhost:9200/ctim/_delete_by_query"
-           (sut/delete-by-query-uri "http://localhost:9200"
-                                    ["ctim"])))
+           (sut/delete-by-query-uri "http://localhost:9200" ["ctim"])))
     (is (= "http://localhost:9200/ctim%2Cctia/_delete_by_query"
-           (sut/delete-by-query-uri "http://localhost:9200"
-                                    ["ctim", "ctia"])))))
+           (sut/delete-by-query-uri "http://localhost:9200" ["ctim", "ctia"]))))
+  (testing "should generate a valid update_by_query uri"
+    (is (= "http://localhost:9200/ctim/_update_by_query"
+           (sut/update-by-query-uri "http://localhost:9200" ["ctim"])))
+    (is (= "http://localhost:9200/ctim%2Cctia/_update_by_query"
+           (sut/update-by-query-uri "http://localhost:9200" ["ctim", "ctia"])))))
 
 (deftest index-doc-uri-test
   (testing "should generate a valid doc URI"

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -730,10 +730,8 @@
             conn
             indexname
             doc-type
-            (assoc-in
-             base-mappings
-             (remove nil? [doc-type :properties :sport :type])
-             "text"))
+            (cond->> {:properties {:sport {:type "text"}}}
+              (= version 5) (assoc {} doc-type)))
 
            ;; since mapping was updated _after_ we inserted data, :sport field still
            ;; not indexed, and searching on that field still shouldn't get anything


### PR DESCRIPTION
Implements [_update_by_query](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html)
Closes: https://github.com/advthreat/iroh/issues/5786

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

e2dc938 linter config
43e95bf update_by_query basics
ee3154d adds another test case
99c8185 gitignores
afd1370 fixes the test, making it work properly for both v5 and v7
0211542 sustainable polar bearing. doseq -> bulk-create-docs
88a18c8 improve the test
b5636d6 no need to pass the whole mapping, only the update
31db58f origin/update_by_query_#5786 Adds additional test case