### PR TITLE
Document raw `:sort` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,9 @@ it will return not only the matched documents but also meta data like `_index` a
   :next {:limit 2, :offset 2, :search_after [1]},
   :sort [1]}}
 ```
-Ductile also provides a search function with a simple interface that offers to use a Mongo like filters lucene query string to easily match documents
+Ductile also provides a search function with a simple interface that offers to use a Mongo like filters lucene query string to easily match documents.
+`:sort` uses the same format as ElasticSearch's [sort parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html), except via
+EDN.
 
 ```clojure
 (es-doc/search-docs c
@@ -357,54 +359,6 @@ Ductile also provides a search function with a simple interface that offers to u
                     {:age 36}
                     {:sort {:name {:order :desc}}})
 ```
-
-### Sorting
-
-Ductile exposes ElasticSearch's [sort parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html) for sorting query results as EDN.
-
-Sort by field:
-
-```clojure
-(es-doc/query c
-              "test-index"
-              (es-query/ids [1 2])
-              ;; sort by severity field
-              {:sort "severity"})
-
-(es-doc/query c
-              "test-index"
-              (es-query/ids [1 2])
-              ;; sort by the `severity` field in :asc[ending] or :desc[ending] order
-              {:sort {"severity" :asc}})
-```
-
-[Script sort](https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html):
-
-```clojure
-(es-doc/query c
-              "test-index"
-              (es-query/ids [1 2])
-              {:sort 
-               {:_script {:type "number",
-                          :script {:lang "painless",
-                                   :source "doc['theatre'].value.length() * params.factor",
-                                   :params {"factor" 1.1}}
-                          :order "asc"}}})
-```
-
-Sort by multiple fields:
-```clojure
-(es-doc/query c
-              "test-index"
-              (es-query/ids [1 2])
-              {:sort 
-               [{"post_date" {:order "asc" :format "strict_date_optional_time_nanos"}}
-                "user"
-                {"name" "desc"},
-                {"age" "desc"},
-                "_score"]})
-```
-
 
 ### Test stubbing
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The `version` field accepts an integer value to specify the major Elasticsearch 
                    {:refresh "wait_for"})
 ```
   
-```javascript
+```clojure
 {:id 1, :name "John Doe", :description "an anonymous coward"}
 ```
 
@@ -148,7 +148,7 @@ if you try to create another document with the same id, it will throw an Excepti
 ```
 it will return the document creation result
 
-```javascript
+```clojure
  {:_index "test-index",
   :_type "_doc",
   :_id "1",
@@ -168,7 +168,7 @@ if you do not provide the id field, elasticsearch will insert the document and g
                     :description "yet another anonymous coward"}
                    {:refresh "wait_for"})
 ```
-```javascript
+```clojure
  {:_index "test-index",
   :_type "_doc",
   :_id "EBD9L3ABLWPPOW84CV6I",
@@ -190,7 +190,7 @@ Using the field `id` as document id is the default behavior. However you can pro
                    :mk-id :uri})
 ```
 
-```javascript
+```clojure
  {:_index "test-index",
   :_type "_doc",
   :_id "http://cisco.com/sighting/1",
@@ -210,7 +210,7 @@ another example with a function that return the hash of the created document
                    {:refresh "wait_for"
                    :mk-id hash})
 ```
-```javascript
+```clojure
  {:_index "test-index",
   :_type "_doc",
   :_id "1474268975",
@@ -250,7 +250,7 @@ the 4th parameter offers to set the `refresh` parameter and can take same string
                    {:refresh "wait_for"})
 ```
 it returns the patched document
-```javascript
+```clojure
 {:id 1, :name "Jane Doe", :description "anonymous with know age", :age 36}
 ```
  
@@ -262,7 +262,7 @@ it returns the patched document
                 1
                 {})
 ```
-```javascript
+```clojure
 {:id 1, :name "Jane Doe", :description "anonymous with know age", :age 36}
 ```
    
@@ -295,7 +295,7 @@ Any of the previous functions can be used on an Elasticsearch 5.x cluster by spe
                 1
                 {})
 ```
-```javascript
+```clojure
 {:id 1, :name "Jane Doe", :description "anonymous with know age", :age 36}
 ```
 
@@ -309,7 +309,7 @@ you can either provide classical elasticsearch queries or use some helpers from 
               (es-query/ids [1 2])
               {})
 ```
-```javascript
+```clojure
 {:data
  ({:id 2, :name "Jane Doe", :description "another anonymous coward"}),
  :paging {:total-hits 1}}
@@ -327,7 +327,7 @@ if you need all metadata you can use the full-hits? option
 ```
 it will return not only the matched documents but also meta data like `_index` and `_score`
 
-```javascript
+```clojure
 {:data
  [{:_index "test-index",
    :_type "_doc",
@@ -357,6 +357,55 @@ Ductile also provides a search function with a simple interface that offers to u
                     {:age 36}
                     {:sort {:name {:order :desc}}})
 ```
+
+### Sorting
+
+Ductile provides sugar for sorting query results.
+
+Sort by field:
+
+```clojure
+(es-doc/query c
+              "test-index"
+              (es-query/ids [1 2])
+              {:sort [{:op :field
+                       ;; sort by the `severity` field
+                       :field-name "severity"
+                       ;; sort by :asc[ending] (default) or :desc[ending] order
+                       :sort_order :asc}]})
+```
+
+Sort by remapping an existing field:
+
+```clojure
+(es-doc/query c
+              "test-index"
+              (es-query/ids [1 2])
+              {:sort [{:op :remap
+                       ;; use `severity` field to sort fields
+                       :field-name "severity"
+                       ;; .. by remapping each `severity` to a :number or :string
+                       :remap-type :number
+                       ;; .. where severity=critical maps to 1, severity=high maps to 2
+                       :remappings {"Critical" 1
+                                    "High" 2}
+                       ;; .. and other values map to 0
+                       :remap-default 0
+                       ;; sort remapped values in :asc[ending] (default) or :desc[ending] order
+                       :sort_order :asc}]})
+```
+
+Sort by multiple fields:
+```clojure
+(es-doc/query c
+              "test-index"
+              (es-query/ids [1 2])
+              {:sort [;; sort first by severity...
+                      {:op :field :field-name "severity"}
+                      ;; then by revision
+                      {:op :field :field-name "revision"}]})
+```
+
 
 ### Test stubbing
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Sort by field:
                {:_script {:type "number",
                           :script {:lang "painless",
                                    :source "doc['theatre'].value.length() * params.factor",
-                                   :params {"factor": 1.1}}
+                                   :params {"factor" 1.1}}
                           :order "asc"}}})
 ```
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Sort by field:
               {:sort [{:op :field
                        ;; sort by the `severity` field
                        :field-name "severity"
-                       ;; sort by :asc[ending] (default) or :desc[ending] order
+                       ;; sort in :asc[ending] (default) or :desc[ending] order
                        :sort_order :asc}]})
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,9 @@
   :plugins [[lein-codox "0.10.7"]
             [lein-pprint "1.3.2"]]
   :target-path "target/%s"
+  :test-selectors {:default (complement :integration)
+                   :integration :integration
+                   :all (constantly true)}
   :profiles {:uberjar {:aot :all
                        :pedantic? :abort}
              :dev {:dependencies

--- a/src/ductile/conn.clj
+++ b/src/ductile/conn.clj
@@ -73,7 +73,7 @@
             (throw (ex-info "ES query parsing error"
                             {:type ::invalid-request
                              :es-http-res res})))
-    (do (log/warn "ES Unknow Error:" res)
+    (do (log/warn "ES Unknown Error:" res)
         (throw (ex-info "ES Unknown Error"
                         {:type ::es-unknown-error
                          :es-http-res res})))))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -480,8 +480,9 @@
                                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
                                            [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { Debug.explain(doc.containsKey('%s')); return params.default }"
                                                     field-name field-name field-name)
-                                            (format "return Debug.explain(params.remappings.getOrDefault(doc['%s'].value, params.default))"
-                                                    field-name)])
+                                            (format "Debug.explain(params.remappings.getOrDefault(doc['%s'].value, params.default))"
+                                                    field-name)
+                                            "return 0"])
                                  :params {:remappings remappings
                                           :default remap-default}}
                         :order order}}))))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -472,9 +472,6 @@
 
 (defn generate-search-params
   [query aggs params]
-  (assert (not (and (:sort_by params)
-                    (:sort params)))
-          "Don't mix :sort and :sort_by")
   (cond-> (into (params->pagination params)
                 (select-keys params [:sort :_source :track_total_hits]))
     query (assoc :query query)

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -476,7 +476,7 @@
                                                           ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
                                                           :inline (format "params[doc['%s']] ?: 0" field-name)
                                                           :params mapping}
-                                                 :order }})))
+                                                 :order order}})))
                sort_by_ext)})
 
 (defn params->pagination

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -478,7 +478,7 @@
                                  :inline (string/join
                                            "\n"
                                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
-                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { return Debug.explain(params.default) }"
+                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { Debug.explain(doc['%s']); return params.default }"
                                                     field-name field-name)
                                             (format "return Debug.explain(params.remappings.getOrDefault(doc['%s'].value, params.default))"
                                                     field-name)])

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -453,6 +453,7 @@
 
 (defn sort-params-ext
   [sort_by_ext default-sort_order]
+  (assert (sequential? sort_by_ext))
   {:sort (mapv (fn [{:keys [op field-name sort_order] :as params}]
                  (let [order (or default-sort_order sort_order)]
                   (assert (keyword? order) (pr-str order))
@@ -504,17 +505,17 @@
   )
 
 (defn params->pagination
-  [{:keys [sort_by sort_by_ext sort_order offset limit search_after]
+  [{:keys [sort_by sort_order offset limit search_after]
     :or {sort_order :asc
          limit pagination/default-limit} :as opt}]
-  (assert (not (and sort_by sort_by_ext))
-          "Cannot provide both :sort_by and :sort_by_ext")
   (merge
    {}
    (when sort_by
-     (sort-params sort_by sort_order))
-   (when sort_by_ext
-     (sort-params-ext sort_by_ext sort_order))
+     (if (string? sort_by)
+       ((if (string? sort_by)
+          sort-params
+          sort-params-ext)
+        sort_by sort_order)))
    (when limit
      {:size limit})
    (when (and offset

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -476,8 +476,14 @@
                        {:type (name remap-type)
                         :script {:lang "painless"
                                  ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
-                                 :inline (format "params.remappings[doc['%s']] ?: params.default"
-                                                 field-name)
+                                 :inline (string/join
+                                           "\n"
+                                           [(format "fieldVal = doc['%s'];" field-name)
+                                            "if(fieldVal == null) {"
+                                            "  return params.default"
+                                            "} else {"
+                                            "  params.remappings.getOrDefault(fieldVal, params.default)"
+                                            "}"])
                                  :params {:remappings remappings
                                           :default remap-default}}
                         :order order}}))))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -497,21 +497,6 @@
                         :order order}}))))
                sort_by_ext)})
 
-(comment
-  (sort-params-ext
-    [{:op :field
-      :field-name "Severity"
-      :sort_order :asc}
-     {:op :remap
-      :remap-type :number
-      :field-name "Severity"
-      :remappings {"Critical" 0
-                   "High" 1}
-      :sort_order :asc
-      :remap-default 0}]
-    :asc)
-  )
-
 (defn sort-params
   [sort_by sort_order]
   (if (coll? sort_by)

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -478,7 +478,7 @@
                                  :inline (string/join
                                            "\n"
                                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
-                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { Debug.explain(doc['%s']); return params.default }"
+                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { Debug.explain(doc); return params.default }"
                                                     field-name field-name)
                                             (format "return Debug.explain(params.remappings.getOrDefault(doc['%s'].value, params.default))"
                                                     field-name)])

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -480,9 +480,9 @@
                                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
                                            [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { Debug.explain(doc.containsKey('%s')); return params.default }"
                                                     field-name field-name field-name)
-                                            (format "Debug.explain(params.remappings.getOrDefault(doc['%s'].value, params.default))"
+                                            (format "Debug.explain(params.remappings.getOrDefault(doc['%s'].value, params.default));"
                                                     field-name)
-                                            "return 0"])
+                                            "return params.remappings.getOrDefault(doc['%s'].value, params.default)"])
                                  :params {:remappings remappings
                                           :default remap-default}}
                         :order order}}))))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -441,63 +441,6 @@
       request-fn
       conn/safe-es-read))
 
-#_
-(defn sort-params-ext
-  [sort_by_ext default-sort_order]
-  (assert (sequential? sort_by_ext))
-  {:sort (mapv (fn [{:keys [op field-name sort_order] :as params}]
-                 (let [field-name (name field-name)
-                       order (keyword (or sort_order default-sort_order))]
-                  (assert (keyword? order) (pr-str order))
-                  (assert (not (some #{"'"} field-name)) (pr-str field-name))
-                  (case op
-                    ;; eg
-                    ;; {:op :field
-                    ;;  :field-name "Severity"
-                    ;;  :sort_order :asc}
-                    :field
-                    ;; https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#_sort_values
-                    {field-name {:order order}}
-
-                    ;; eg
-                    ;; {:op :remap
-                    ;;  :remap-type :number
-                    ;;  :field-name "severity"
-                    ;;  :remappings {"Critical" 0
-                    ;;               "High" 1}
-                    ;;  :sort_order :asc
-                    ;;  :remap-default 0}
-                    :remap
-                    (let [{:keys [remap-type remap-default remappings]} params
-                          remappings (into {} (map (fn [e]
-                                                     (update e 0 #(cond-> %
-                                                                    (string? %) string/lower-case))))
-                                           remappings)]
-                      (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
-                      (assert ((every-pred map? seq) remappings) (pr-str remappings))
-                      (assert (some? remap-default) (pr-str remap-default))
-                      (assert (every? string? (keys remappings)) remappings)
-                      (case remap-type
-                        :number (do (assert (number? remap-default) remap-default)
-                                    (assert (every? number? (vals remappings)) remappings))
-                        :string (do (assert (string? remap-default) remap-default)
-                                    (assert (every? string? (vals remappings)) remappings)))
-                      ;; https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html
-                      {:_script
-                       {:type (name remap-type)
-                        :script {:lang "painless"
-                                 :inline (string/join
-                                           "\n"
-                                           ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
-                                           [(format "if (!doc.containsKey('%s') || doc['%s'].size() != 1) { return params.default }"
-                                                    field-name field-name)
-                                            (format "return params.remappings.getOrDefault(doc['%s'].value, params.default)"
-                                                    field-name)])
-                                 :params {:remappings remappings
-                                          :default remap-default}}
-                        :order order}}))))
-               sort_by_ext)})
-
 (defn sort-params
   [sort_by sort_order]
   (let [sort-fields

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -482,6 +482,7 @@
                                             "if(fieldVal == null) {"
                                             "  return params.default"
                                             "} else {"
+                                            "  Debug.explain(params.remappings);"
                                             "  return params.remappings.getOrDefault(fieldVal, params.default)"
                                             "}"])
                                  :params {:remappings remappings

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -475,11 +475,11 @@
                       {:_script
                        {:type (name remap-type)
                         :script {:lang "painless"
-                                 ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
                                  :inline (string/join
                                            "\n"
                                            [(format "String fieldVal = doc['%s']?.value;" field-name)
                                             "if(fieldVal == null) {"
+                                            "  Debug.explain('default!!');"
                                             "  return params.default"
                                             "} else {"
                                             "  Debug.explain(params.remappings);"

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -1,7 +1,6 @@
 (ns ductile.document
   (:require [cemerick.uri :as uri]
             [cheshire.core :as json]
-            [clojure.edn :as edn]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
             [ductile.conn :as conn]
@@ -450,9 +449,7 @@
                  {field-name
                   {:order (keyword (or field-order sort_order))}}))
              (string/split (name sort_by) #","))]
-
-    ;; FIXME hash map loses ordering, "sort" accepts a list
-    {:sort (into {} sort-fields)}))
+    {:sort sort-fields}))
 
 (defn sort-params-ext
   [sort_by_ext default-sort_order]

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -482,7 +482,7 @@
                                             "if(fieldVal == null) {"
                                             "  return params.default"
                                             "} else {"
-                                            "  params.remappings.getOrDefault(fieldVal, params.default)"
+                                            "  return params.remappings.getOrDefault(fieldVal, params.default)"
                                             "}"])
                                  :params {:remappings remappings
                                           :default remap-default}}

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -478,11 +478,10 @@
                                  :inline (string/join
                                            "\n"
                                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
-                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { Debug.explain(doc.containsKey('%s')); return params.default }"
+                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { return params.default }"
                                                     field-name field-name field-name)
-                                            (format "Debug.explain(params.remappings.getOrDefault(doc['%s'].value, params.default));"
-                                                    field-name)
-                                            "return params.remappings.getOrDefault(doc['%s'].value, params.default)"])
+                                            (format "return params.remappings.getOrDefault(doc['%s'].value, params.default)"
+                                                    field-name)])
                                  :params {:remappings remappings
                                           :default remap-default}}
                         :order order}}))))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -445,9 +445,9 @@
   [sort_by_ext default-sort_order]
   (assert (sequential? sort_by_ext))
   {:sort (mapv (fn [{:keys [op field-name sort_order] :as params}]
-                 (let [order (keyword (or sort_order default-sort_order))]
+                 (let [field-name (name field-name)
+                       order (keyword (or sort_order default-sort_order))]
                   (assert (keyword? order) (pr-str order))
-                  (assert (string? field-name) (pr-str field-name))
                   (assert (not (some #{"'"} field-name)) (pr-str field-name))
                   (case op
                     ;; eg

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -469,15 +469,14 @@
                     :remap
                     (let [{:keys [remap-type remap-default remappings]} params]
                       (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
-                      (assert (seq remappings) (pr-str remappings))
+                      (assert ((every-pred map? seq) remappings) (pr-str remappings))
                       (assert (some? remap-default) (pr-str remap-default))
                       (assert (every? string? (keys remappings)) remappings)
                       (case remap-type
                         :number (do (assert (number? remap-default) remap-default)
-                                    (assert (every? number? (keys remappings)) remappings)
-                                    )
+                                    (assert (every? number? (vals remappings)) remappings))
                         :string (do (assert (string? remap-default) remap-default)
-                                    (assert (every? string? (keys remappings)) remappings)))
+                                    (assert (every? string? (vals remappings)) remappings)))
                       ;; https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html
                       {:_script
                        {:type (name remap-type)

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -511,11 +511,10 @@
   (merge
    {}
    (when sort_by
-     (if (string? sort_by)
-       ((if (string? sort_by)
-          sort-params
-          sort-params-ext)
-        sort_by sort_order)))
+     ((if (string? sort_by)
+        sort-params
+        sort-params-ext)
+      sort_by sort_order))
    (when limit
      {:size limit})
    (when (and offset

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -469,9 +469,8 @@
                     :remap
                     (let [{:keys [remap-type remap-default remappings]} params
                           remappings (into {} (map (fn [e]
-                                                     (mapv #(cond-> %
-                                                              (string? %) string/lower-case)
-                                                           e)))
+                                                     (update e 0 #(cond-> %
+                                                                    (string? %) string/lower-case))))
                                            remappings)]
                       (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
                       (assert ((every-pred map? seq) remappings) (pr-str remappings))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -453,17 +453,17 @@
 
 (defn sort-params-ext
   [sort_by_ext default-sort_order]
-  {:sort (mapv (fn [{:keys [op] :as params}]
+  {:sort (mapv (fn [{:keys [op field-name sort_order] :as params}
+                    order (or default-sort_order sort_order)]
+                 (assert (keyword? order) (pr-str order))
+                 (assert (string? field-name) (pr-str field-name))
+                 (assert (not (some #{"'"} field-name)) (pr-str field-name))
                  (case op
                    ;; eg
                    #_{:op :field
                       :field-name "Severity"
                       :sort_order :asc}
-                   :field (let [{:keys [field-name sort_order]} params
-                                order (or default-sort_order sort_order)]
-                            (assert (keyword? order) (pr-str order))
-                            (assert (string? field-name) (pr-str field-name))
-                            {field-name {:order order}})
+                   :field {field-name {:order order}}
                    ;; eg
                    #_{:op :remap
                       :remap-type :number
@@ -472,12 +472,8 @@
                                    "High" 1}
                       :sort_order :asc
                       :remap-default 0}
-                   :remap (let [{:keys [remap-type remap-default field-name remappings sort_order]} params
-                                order (or default-sort_order sort_order)]
+                   :remap (let [{:keys [remap-type remap-default remappings]} params]
                             (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
-                            (assert (string? field-name) (pr-str field-name))
-                            (assert (not (some #{"'"} field-name)) (pr-str field-name))
-                            (assert (keyword? order) (pr-str order))
                             (assert (seq remappings) (pr-str remappings))
                             ;; https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html
                             {:_script

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -461,7 +461,7 @@
                     ;; eg
                     ;; {:op :remap
                     ;;  :remap-type :number
-                    ;;  :field-name "Severity"
+                    ;;  :field-name "severity"
                     ;;  :remappings {"Critical" 0
                     ;;               "High" 1}
                     ;;  :sort_order :asc

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -477,14 +477,10 @@
                         :script {:lang "painless"
                                  :inline (string/join
                                            "\n"
-                                           [(format "String fieldVal = doc['%s']?.value;" field-name)
-                                            "if(fieldVal == null) {"
-                                            "  Debug.explain('default!!');"
-                                            "  return params.default"
-                                            "} else {"
-                                            "  Debug.explain(params.remappings);"
-                                            "  return params.remappings.getOrDefault(fieldVal, params.default)"
-                                            "}"])
+                                           ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
+                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { return params.default }" field-name field-name)
+                                            (format "String fieldVal = doc['%s']?.value;" field-name)
+                                            "return params.remappings.getOrDefault(fieldVal, params.default)"])
                                  :params {:remappings remappings
                                           :default remap-default}}
                         :order order}}))))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -444,11 +444,11 @@
 (defn sort-params
   [sort_by sort_order]
   (let [sort-fields
-        (map (fn [field]
-               (let [[field-name field-order] (string/split field #":")]
-                 {field-name
-                  {:order (keyword (or field-order sort_order))}}))
-             (string/split (name sort_by) #","))]
+        (mapv (fn [field]
+                (let [[field-name field-order] (string/split field #":")]
+                  {field-name
+                   {:order (keyword (or field-order sort_order))}}))
+              (string/split (name sort_by) #","))]
     {:sort sort-fields}))
 
 (defn sort-params-ext

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -478,8 +478,8 @@
                                  :inline (string/join
                                            "\n"
                                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
-                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { Debug.explain(doc); return params.default }"
-                                                    field-name field-name)
+                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { Debug.explain(doc.containsKey('%s')); return params.default }"
+                                                    field-name field-name field-name)
                                             (format "return Debug.explain(params.remappings.getOrDefault(doc['%s'].value, params.default))"
                                                     field-name)])
                                  :params {:remappings remappings

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -453,38 +453,38 @@
 
 (defn sort-params-ext
   [sort_by_ext default-sort_order]
-  {:sort (mapv (fn [{:keys [op field-name sort_order] :as params}
-                    order (or default-sort_order sort_order)]
-                 (assert (keyword? order) (pr-str order))
-                 (assert (string? field-name) (pr-str field-name))
-                 (assert (not (some #{"'"} field-name)) (pr-str field-name))
-                 (case op
-                   ;; eg
-                   #_{:op :field
-                      :field-name "Severity"
-                      :sort_order :asc}
-                   :field {field-name {:order order}}
-                   ;; eg
-                   #_{:op :remap
-                      :remap-type :number
-                      :field-name "Severity"
-                      :remappings {"Critical" 0
-                                   "High" 1}
-                      :sort_order :asc
-                      :remap-default 0}
-                   :remap (let [{:keys [remap-type remap-default remappings]} params]
-                            (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
-                            (assert (seq remappings) (pr-str remappings))
-                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html
-                            {:_script
-                             {:type (name remap-type)
-                              :script {:lang "painless"
-                                       ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
-                                       :inline (format "params.remappings[doc['%s']] ?: params.default"
-                                                       field-name)
-                                       :params {:remappings remappings
-                                                :default remap-default}}
-                              :order order}})))
+  {:sort (mapv (fn [{:keys [op field-name sort_order] :as params}]
+                 (let [order (or default-sort_order sort_order)]
+                  (assert (keyword? order) (pr-str order))
+                  (assert (string? field-name) (pr-str field-name))
+                  (assert (not (some #{"'"} field-name)) (pr-str field-name))
+                  (case op
+                    ;; eg
+                    #_{:op :field
+                       :field-name "Severity"
+                       :sort_order :asc}
+                    :field {field-name {:order order}}
+                    ;; eg
+                    #_{:op :remap
+                       :remap-type :number
+                       :field-name "Severity"
+                       :remappings {"Critical" 0
+                                    "High" 1}
+                       :sort_order :asc
+                       :remap-default 0}
+                    :remap (let [{:keys [remap-type remap-default remappings]} params]
+                             (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
+                             (assert (seq remappings) (pr-str remappings))
+                             ;; https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html
+                             {:_script
+                              {:type (name remap-type)
+                               :script {:lang "painless"
+                                        ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
+                                        :inline (format "params.remappings[doc['%s']] ?: params.default"
+                                                        field-name)
+                                        :params {:remappings remappings
+                                                 :default remap-default}}
+                               :order order}}))))
                sort_by_ext)})
 
 (defn params->pagination

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -475,6 +475,7 @@
                     :remap (let [{:keys [remap-type remap-default remappings]} params]
                              (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
                              (assert (seq remappings) (pr-str remappings))
+                             (assert (some? remap-default) (pr-str remap-default))
                              ;; https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html
                              {:_script
                               {:type (name remap-type)
@@ -486,6 +487,21 @@
                                                  :default remap-default}}
                                :order order}}))))
                sort_by_ext)})
+
+(comment
+  (sort-params-ext
+    [{:op :field
+      :field-name "Severity"
+      :sort_order :asc}
+     {:op :remap
+      :remap-type :number
+      :field-name "Severity"
+      :remappings {"Critical" 0
+                   "High" 1}
+      :sort_order :asc
+      :remap-default 0}]
+    :asc)
+  )
 
 (defn params->pagination
   [{:keys [sort_by sort_by_ext sort_order offset limit search_after]

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -467,7 +467,12 @@
                     ;;  :sort_order :asc
                     ;;  :remap-default 0}
                     :remap
-                    (let [{:keys [remap-type remap-default remappings]} params]
+                    (let [{:keys [remap-type remap-default remappings]} params
+                          remappings (into {} (map (fn [e]
+                                                     (mapv #(cond-> %
+                                                              (string? %) string/lower-case)
+                                                           e)))
+                                           remappings)]
                       (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
                       (assert ((every-pred map? seq) remappings) (pr-str remappings))
                       (assert (some? remap-default) (pr-str remap-default))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -484,7 +484,8 @@
                              {:type (name remap-type)
                               :script {:lang "painless"
                                        ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
-                                       :inline (format "params.remappings[doc['%s']] ?: params.default" field-name)
+                                       :inline (format "params.remappings[doc['%s']] ?: params.default"
+                                                       field-name)
                                        :params {:remappings remappings
                                                 :default remap-default}}
                               :order order}})))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -478,7 +478,7 @@
                                  ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
                                  :inline (string/join
                                            "\n"
-                                           [(format "String fieldVal = doc['%s'];" field-name)
+                                           [(format "String fieldVal = doc['%s']?.value;" field-name)
                                             "if(fieldVal == null) {"
                                             "  return params.default"
                                             "} else {"

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -451,32 +451,36 @@
                   (assert (not (some #{"'"} field-name)) (pr-str field-name))
                   (case op
                     ;; eg
-                    #_{:op :field
-                       :field-name "Severity"
-                       :sort_order :asc}
-                    :field {field-name {:order order}}
+                    ;; {:op :field
+                    ;;  :field-name "Severity"
+                    ;;  :sort_order :asc}
+                    :field
+                    ;; https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#_sort_values
+                    {field-name {:order order}}
+
                     ;; eg
-                    #_{:op :remap
-                       :remap-type :number
-                       :field-name "Severity"
-                       :remappings {"Critical" 0
-                                    "High" 1}
-                       :sort_order :asc
-                       :remap-default 0}
-                    :remap (let [{:keys [remap-type remap-default remappings]} params]
-                             (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
-                             (assert (seq remappings) (pr-str remappings))
-                             (assert (some? remap-default) (pr-str remap-default))
-                             ;; https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html
-                             {:_script
-                              {:type (name remap-type)
-                               :script {:lang "painless"
-                                        ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
-                                        :inline (format "params.remappings[doc['%s']] ?: params.default"
-                                                        field-name)
-                                        :params {:remappings remappings
-                                                 :default remap-default}}
-                               :order order}}))))
+                    ;; {:op :remap
+                    ;;  :remap-type :number
+                    ;;  :field-name "Severity"
+                    ;;  :remappings {"Critical" 0
+                    ;;               "High" 1}
+                    ;;  :sort_order :asc
+                    ;;  :remap-default 0}
+                    :remap
+                    (let [{:keys [remap-type remap-default remappings]} params]
+                      (assert ((some-fn string? simple-keyword?) remap-type) (str "Expected eg., :remap-type :number, actual " (pr-str remap-type)))
+                      (assert (seq remappings) (pr-str remappings))
+                      (assert (some? remap-default) (pr-str remap-default))
+                      ;; https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-sort-context.html
+                      {:_script
+                       {:type (name remap-type)
+                        :script {:lang "painless"
+                                 ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
+                                 :inline (format "params.remappings[doc['%s']] ?: params.default"
+                                                 field-name)
+                                 :params {:remappings remappings
+                                          :default remap-default}}
+                        :order order}}))))
                sort_by_ext)})
 
 (comment

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -605,8 +605,6 @@
                                       nil)
                  (assoc :method :post
                         :url (search-uri uri index-name))
-                 (doto
-                   (prn `query))
                  request-fn
                  conn/safe-es-read)]
      (log/debug "search:" search-params)

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -595,6 +595,8 @@
                                       nil)
                  (assoc :method :post
                         :url (search-uri uri index-name))
+                 (doto
+                   (prn `query))
                  request-fn
                  conn/safe-es-read)]
      (log/debug "search:" search-params)

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -458,7 +458,7 @@
                    ;; eg
                    #_{:op :field
                       :field-name "Severity"
-                      :sort_order :ASC}
+                      :sort_order :asc}
                    :field (let [{:keys [field-name sort_order]} params
                                 order (or default-sort_order sort_order)]
                             (assert (keyword? order) (pr-str order))
@@ -470,7 +470,7 @@
                       :field-name "Severity"
                       :remappings {"Critical" 0
                                    "High" 1}
-                      :sort_order :ASC
+                      :sort_order :asc
                       :remap-default 0}
                    :remap (let [{:keys [remap-type remap-default field-name remappings sort_order]} params
                                 order (or default-sort_order sort_order)]

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -499,12 +499,13 @@
   (if (coll? sort_by)
     (sort-params-ext sort_by sort_order)
     (let [sort-fields
-          (mapv (fn [field]
-                  (let [[field-name field-order] (string/split field #":")]
-                    {field-name
-                     {:order (keyword (or field-order sort_order))}}))
-                (string/split (name sort_by) #","))]
-      {:sort sort-fields})))
+          (map (fn [field]
+                 (let [[field-name field-order] (string/split field #":")]
+                   {field-name
+                    {:order (keyword (or field-order sort_order))}}))
+               (string/split (name sort_by) #","))]
+      ;; FIXME hash map loses ordering, use vector
+      {:sort (into {} sort-fields)})))
 
 (defn params->pagination
   [{:keys [sort_by sort_order offset limit search_after]

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -478,9 +478,10 @@
                                  :inline (string/join
                                            "\n"
                                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
-                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { return params.default }" field-name field-name)
-                                            (format "String fieldVal = doc['%s'].value;" field-name)
-                                            "return Debug.explain(params.remappings.getOrDefault(fieldVal, params.default))"])
+                                           [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { return Debug.explain(params.default) }"
+                                                    field-name field-name)
+                                            (format "return Debug.explain(params.remappings.getOrDefault(doc['%s'].value, params.default))"
+                                                    field-name)])
                                  :params {:remappings remappings
                                           :default remap-default}}
                         :order order}}))))

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -457,14 +457,16 @@
   [{es-sort :sort :keys [offset limit search_after]
     :or {limit pagination/default-limit} :as opt}]
   (cond-> (if-some [sort_by (:sort_by opt)]
-            (let [_ (assert (not es-sort) "Cannot provide both :sort_by and :sort")
+            (let [_ (assert (not es-sort) (str "Cannot provide both :sort_by and :sort"
+                                               (select-keys opt [:sort_by :sort_order :sort])))
                   res (sort-params sort_by (:sort_order opt :asc))]
               (binding [*out* *err*]
                 (println (format "DEPRECATED: ductile %s -- use %s"
                                  (select-keys opt [:sort_by :sort_order])
                                  res)))
               res)
-            (do (assert (not (:sort_order opt)) "Cannot provide both :sort_order and :sort")
+            (do (assert (not (:sort_order opt)) (str "Cannot provide both :sort_order and :sort"
+                                                     (select-keys opt [:sort_order :sort])))
                 (select-keys opt [:sort])))
     limit (assoc :size limit)
 

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -478,7 +478,7 @@
                                  ;; https://www.elastic.co/guide/en/elasticsearch/painless/5.6/_operators.html#_elvis
                                  :inline (string/join
                                            "\n"
-                                           [(format "fieldVal = doc['%s'];" field-name)
+                                           [(format "String fieldVal = doc['%s'];" field-name)
                                             "if(fieldVal == null) {"
                                             "  return params.default"
                                             "} else {"

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -514,7 +514,7 @@
 (defn params->pagination
   [{:keys [sort_by sort_order offset limit search_after]
     :or {sort_order :asc
-         limit pagination/default-limit} :as opt}]
+         limit pagination/default-limit}}]
   (merge
    {}
    (when sort_by

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -479,7 +479,7 @@
                                            "\n"
                                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
                                            [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { return params.default }" field-name field-name)
-                                            (format "String fieldVal = doc['%s']?.value;" field-name)
+                                            (format "String fieldVal = doc['%s'].value;" field-name)
                                             "return params.remappings.getOrDefault(fieldVal, params.default)"])
                                  :params {:remappings remappings
                                           :default remap-default}}

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -480,7 +480,7 @@
                                            ;; https://www.elastic.co/guide/en/elasticsearch/painless/8.1/painless-walkthrough.html#_missing_keys
                                            [(format "if (!doc.containsKey('%s') || doc['%s'].empty) { return params.default }" field-name field-name)
                                             (format "String fieldVal = doc['%s'].value;" field-name)
-                                            "return params.remappings.getOrDefault(fieldVal, params.default)"])
+                                            "return Debug.explain(params.remappings.getOrDefault(fieldVal, params.default))"])
                                  :params {:remappings remappings
                                           :default remap-default}}
                         :order order}}))))

--- a/src/ductile/query.clj
+++ b/src/ductile/query.clj
@@ -44,15 +44,15 @@
 
 we force all values to lowercase, since our indexing does the same for all terms."
   [filters]
-  (vec (map (fn [[k v]]
-              (terms (->> k
-                          (map name)
-                          (str/join "."))
-                     (map #(if (string? %)
-                             (str/lower-case %)
-                             %)
-                          (if (coll? v) v [v]))))
-            filters)))
+  (mapv (fn [[k v]]
+          (terms (->> k
+                      (map name)
+                      (str/join "."))
+                 (map #(if (string? %)
+                         (str/lower-case %)
+                         %)
+                      (if (coll? v) v [v]))))
+        filters))
 
 (defn prepare-terms [filter-map]
   (let [terms (map (fn [[k v]]

--- a/test/ductile/auth/api_key_test.clj
+++ b/test/ductile/auth/api_key_test.clj
@@ -10,7 +10,7 @@
   (is (= "https://cisco.com/_security/api_key"
          (sut/api-key-uri "https://cisco.com"))))
 
-(deftest create-api-key!-test
+(deftest ^:integration create-api-key!-test
   (is (set/subset? #{:id :api_key}
                    (-> (connect 7 basic-auth-opts)
                        (sut/create-api-key! {:name "my-api-key"})

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -75,38 +75,32 @@
 (deftest params->pagination-test
   (is (= {:size 100
           :sort [{"field1" {:order :asc}}]}
-         (sut/params->pagination {:sort_by :field1})
-         (sut/params->pagination {:sort [{"field1" {:order :asc}}]})))
+         (sut/params->pagination {:sort_by :field1})))
 
   (is (= {:size 100
           :sort [{"field1" {:order :desc}}]}
          (sut/params->pagination {:sort_by "field1:desc"})
-         (sut/params->pagination {:sort [{"field1" {:order :desc}}]})))
+         (sut/params->pagination {:sort_by "field1:desc"
+                                  :sort_order :asc})))
 
   (is (= {:size 100
           :sort [{"field1" {:order :desc}}
                  {"field2" {:order :asc}}
                  {"field3" {:order :desc}}]}
          (sut/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"})
-         (sut/params->pagination {:sort [{"field1" {:order :desc}}
-                                         {"field2" {:order :asc}}
-                                         {"field3" {:order :desc}}]})))
+         (sut/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"
+                                  :sort_order :asc})))
 
   (is (= {:size 100
           :from 1000
           :sort [{"field1" {:order :asc}}]}
          (sut/params->pagination {:sort_by :field1
-                                  :offset 1000})
-         (sut/params->pagination {:sort [{"field1" {:order :asc}}]
                                   :offset 1000})))
 
   (is (= {:size 10000
           :from 1000
           :sort [{"field1" {:order :asc}}]}
          (sut/params->pagination {:sort_by :field1
-                                  :offset 1000
-                                  :limit 10000})
-         (sut/params->pagination {:sort [{"field1" {:order :asc}}]
                                   :offset 1000
                                   :limit 10000})))
 
@@ -118,7 +112,7 @@
                                   :offset 1000
                                   :limit 10000
                                   :search_after ["value1"]})
-         (sut/params->pagination {:sort [{"field1" {:order :asc}}]
+         (sut/params->pagination {:sort_by :field1
                                   :limit 10000
                                   :search_after ["value1"]}))))
 

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -150,6 +150,30 @@
          (sut/params->pagination {:sort_by [{:op :field
                                              :field-name "field1"}]
                                   :limit 10000
+                                  :search_after ["value1"]})))
+  (is (= {:sort [{:_script
+                  {:type "number"
+                   :script {:lang "painless"
+                            :inline (str "if (!doc.containsKey('severity') || doc['severity'].size() != 1) { return params.default }\n"
+                                         "return params.remappings.getOrDefault(doc['severity'].value, params.default)")
+                            :params {:remappings {"critical" 0, "high" 1}
+                                     :default 0}}
+                   :order :asc}}
+                 {"field1" {:order :desc}}]
+          :size 10000
+          :from 0
+          :search_after ["value1"]}
+         (sut/params->pagination {:sort_by [{:op :remap
+                                             :remap-type :number
+                                             :remappings {"Critical" 0
+                                                          "High" 1}
+                                             :field-name "severity"
+                                             :sort_order :asc
+                                             :remap-default 0}
+                                            {:op :field
+                                             :field-name "field1"
+                                             :sort_order "desc"}]
+                                  :limit 10000
                                   :search_after ["value1"]}))))
 
 (deftest generate-search-params-test

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -74,45 +74,81 @@
 
 (deftest params->pagination-test
   (is (= {:size 100
-          :sort {"field1" {:order :asc}}}
-         (sut/params->pagination {:sort_by :field1})))
+          :sort [{"field1" {:order :asc}}]}
+         (sut/params->pagination {:sort_by :field1})
+         (sut/params->pagination {:sort_by [{:op :field
+                                             :field-name "field1"}]})))
 
   (is (= {:size 100
-          :sort {"field1" {:order :desc}}}
+          :sort [{"field1" {:order :desc}}]}
          (sut/params->pagination {:sort_by "field1:desc"})
+         (sut/params->pagination {:sort_by [{:op :field
+                                             :field-name "field1"
+                                             :sort_order "desc"}]})
          (sut/params->pagination {:sort_by "field1:desc"
+                                  :sort_order :asc})
+         (sut/params->pagination {:sort_by [{:op :field
+                                             :field-name "field1"
+                                             :sort_order "desc"}]
                                   :sort_order :asc})))
 
   (is (= {:size 100
-          :sort {"field1" {:order :desc}
-                 "field2" {:order :asc}
-                 "field3" {:order :desc}}}
+          :sort [{"field1" {:order :desc}}
+                 {"field2" {:order :asc}}
+                 {"field3" {:order :desc}}]}
          (sut/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"})
+         (sut/params->pagination {:sort_by [{:op :field
+                                             :field-name "field1"
+                                             :sort_order "desc"}
+                                            {:op :field
+                                             :field-name "field2"
+                                             :sort_order "asc"}
+                                            {:op :field
+                                             :field-name "field3"
+                                             :sort_order "desc"}]})
          (sut/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"
+                                  :sort_order :asc})
+         (sut/params->pagination {:sort_by [{:op :field
+                                             :field-name "field1"
+                                             :sort_order "desc"}
+                                            {:op :field
+                                             :field-name "field2"
+                                             :sort_order "asc"}
+                                            {:op :field
+                                             :field-name "field3"
+                                             :sort_order "desc"}]
                                   :sort_order :asc})))
 
   (is (= {:size 100
           :from 1000
-          :sort {"field1" {:order :asc}}}
+          :sort [{"field1" {:order :asc}}]}
          (sut/params->pagination {:sort_by :field1
+                                  :offset 1000})
+         (sut/params->pagination {:sort_by [{:op :field
+                                             :field-name "field1"}]
                                   :offset 1000})))
 
   (is (= {:size 10000
           :from 1000
-          :sort {"field1" {:order :asc}}}
+          :sort [{"field1" {:order :asc}}]}
          (sut/params->pagination {:sort_by :field1
+                                  :offset 1000
+                                  :limit 10000})
+         (sut/params->pagination {:sort_by [{:op :field
+                                             :field-name "field1"}]
                                   :offset 1000
                                   :limit 10000})))
 
   (is (= {:size 10000
           :from 0
           :search_after ["value1"]
-          :sort {"field1" {:order :asc}}}
+          :sort [{"field1" {:order :asc}}]}
          (sut/params->pagination {:sort_by :field1
                                   :offset 1000
                                   :limit 10000
                                   :search_after ["value1"]})
-         (sut/params->pagination {:sort_by :field1
+         (sut/params->pagination {:sort_by [{:op :field
+                                             :field-name "field1"}]
                                   :limit 10000
                                   :search_after ["value1"]}))))
 

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -934,3 +934,30 @@
                                 es-params)
              (pagination-params es7-result
                                 es-params))))))
+
+(deftest sort-params-ext-test
+  ;; example call
+  (is (=
+       {:sort
+        [{"Severity" {:order :asc}}
+         {:_script {:type "number"
+                    :script {:lang "painless"
+                             :inline (str "if (!doc.containsKey('Severity') || doc['Severity'].size() != 1) { return params.default }\n"
+                                          "return params.remappings.getOrDefault(doc['Severity'].value, params.default)")
+                             :params {;; note: lowercased
+                                      :remappings {"critical" 0, "high" 1}
+                                      :default 0}}
+                    :order :asc}}]}
+       (sut/sort-params-ext
+         [{:op :field
+           :field-name "Severity"
+           :sort_order :asc}
+          {:op :remap
+           :remap-type :number
+           :field-name "Severity"
+           ;; note: uppercased keys are lowercased
+           :remappings {"Critical" 0
+                        "High" 1}
+           :sort_order :asc
+           :remap-default 0}]
+         :asc))))

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -76,56 +76,28 @@
   (is (= {:size 100
           :sort [{"field1" {:order :asc}}]}
          (sut/params->pagination {:sort_by :field1})
-         (sut/params->pagination {:sort_by [{:op :field
-                                             :field-name "field1"}]})))
+         (sut/params->pagination {:sort [{"field1" {:order :asc}}]})))
 
   (is (= {:size 100
           :sort [{"field1" {:order :desc}}]}
          (sut/params->pagination {:sort_by "field1:desc"})
-         (sut/params->pagination {:sort_by [{:op :field
-                                             :field-name "field1"
-                                             :sort_order "desc"}]})
-         (sut/params->pagination {:sort_by "field1:desc"
-                                  :sort_order :asc})
-         (sut/params->pagination {:sort_by [{:op :field
-                                             :field-name "field1"
-                                             :sort_order "desc"}]
-                                  :sort_order :asc})))
+         (sut/params->pagination {:sort [{"field1" {:order :desc}}]})))
 
   (is (= {:size 100
           :sort [{"field1" {:order :desc}}
                  {"field2" {:order :asc}}
                  {"field3" {:order :desc}}]}
          (sut/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"})
-         (sut/params->pagination {:sort_by [{:op :field
-                                             :field-name "field1"
-                                             :sort_order "desc"}
-                                            {:op :field
-                                             :field-name "field2"
-                                             :sort_order "asc"}
-                                            {:op :field
-                                             :field-name "field3"
-                                             :sort_order "desc"}]})
-         (sut/params->pagination {:sort_by "field1:desc,field2:asc,field3:desc"
-                                  :sort_order :asc})
-         (sut/params->pagination {:sort_by [{:op :field
-                                             :field-name "field1"
-                                             :sort_order "desc"}
-                                            {:op :field
-                                             :field-name "field2"
-                                             :sort_order "asc"}
-                                            {:op :field
-                                             :field-name "field3"
-                                             :sort_order "desc"}]
-                                  :sort_order :asc})))
+         (sut/params->pagination {:sort [{"field1" {:order :desc}}
+                                         {"field2" {:order :asc}}
+                                         {"field3" {:order :desc}}]})))
 
   (is (= {:size 100
           :from 1000
           :sort [{"field1" {:order :asc}}]}
          (sut/params->pagination {:sort_by :field1
                                   :offset 1000})
-         (sut/params->pagination {:sort_by [{:op :field
-                                             :field-name "field1"}]
+         (sut/params->pagination {:sort [{"field1" {:order :asc}}]
                                   :offset 1000})))
 
   (is (= {:size 10000
@@ -134,8 +106,7 @@
          (sut/params->pagination {:sort_by :field1
                                   :offset 1000
                                   :limit 10000})
-         (sut/params->pagination {:sort_by [{:op :field
-                                             :field-name "field1"}]
+         (sut/params->pagination {:sort [{"field1" {:order :asc}}]
                                   :offset 1000
                                   :limit 10000})))
 
@@ -147,10 +118,10 @@
                                   :offset 1000
                                   :limit 10000
                                   :search_after ["value1"]})
-         (sut/params->pagination {:sort_by [{:op :field
-                                             :field-name "field1"}]
+         (sut/params->pagination {:sort [{"field1" {:order :asc}}]
                                   :limit 10000
                                   :search_after ["value1"]})))
+  #_ ;; TODO move to CTIA
   (testing ":remap default sort order"
     (doseq [sort-order [{}
                         {:sort_order :asc}]]
@@ -179,6 +150,7 @@
                                       :limit 10000
                                       :search_after ["value1"]}))
           sort-order)))
+  #_ ;; TODO move to CTIA
   (testing "remapped string keys are lowercased"
     (is (= {:sort [{:_script
                     {:type "string"
@@ -935,6 +907,7 @@
              (pagination-params es7-result
                                 es-params))))))
 
+#_
 (deftest sort-params-ext-test
   ;; example call
   (is (=

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -724,13 +724,13 @@
                      "the test index was not properly initialized")
 
            ;; insert some documents
-           sample-docs (map #(-> (hash-map :_index indexname
-                                           :_id (str (UUID/randomUUID))
-                                           :_type doc-type
-                                           :name (str "name " %)
-                                           :age %
-                                           ;; one more field that's not indexed yet
-                                           :sport "boxing"))
+           sample-docs (map #(hash-map :_index indexname
+                                       :_id (str (UUID/randomUUID))
+                                       :_type doc-type
+                                       :name (str "name " %)
+                                       :age %
+                                       ;; one more field that's not indexed yet
+                                       :sport "boxing")
                             (range 20))
            _ (sut/bulk-create-docs
               conn

--- a/test/ductile/index_test.clj
+++ b/test/ductile/index_test.clj
@@ -172,7 +172,7 @@
          (is (= "2" number_of_shards))
          (is (= "3" number_of_replicas)))))))
 
-(deftest template-test
+(deftest ^:integration template-test
   (for-each-es-version
    "template crud operations should trigger valid _template requests"
    nil
@@ -225,7 +225,7 @@
      (is (nil? (sut/get-template conn template-name-1)))
      (is (nil? (sut/get-template conn template-name-2))))))
 
-(deftest cat-indices-test
+(deftest ^:integration cat-indices-test
   (for-each-es-version
    "cat-indices shall properly return indices data"
    #(sut/delete! conn "*")


### PR DESCRIPTION
Related: https://github.com/advthreat/iroh/issues/6304

Document ductile's `:sort` which is forwarded as-is to ES.