### PR TITLE
Use UTF-8 encoding for string->bytes conversions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: clojure
 lein: 2.9.1
 dist: trusty
-script: lein do clean, javac, test :all
+script: lein do clean, javac, test :all, with-profile test-encoding test
 
 
 # Cache our Maven deps to be kind to clojars, github, docker images

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It's currently compatible with Elasticsearch 7.x. Ductile proposes a limited sup
 
 ## Changes
 
+- 0.4.5
+  - Fix: Ensure UTF-8 encoding for bulk insert operations
 - 0.4.4
   - Fix: preserve field order when sorting by multiple fields
 - 0.4.3: bad version (failed deployment)

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def test-deps
   `[[ring/ring-codec ~ring-version]])
 
-(defproject threatgrid/ductile "0.4.5-SNAPSHOT"
+(defproject threatgrid/ductile "0.4.5"
   :description "Yet another Clojure client for Elasticsearch REST API, that fits our needs"
   :url "https://github.com/threatgrid/ductile"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -39,5 +39,7 @@
              :test {:dependencies
                     ~test-deps
                     :resource-paths ["test/resources"]
-                    :pedantic? :abort}}
+                    :pedantic? :warn}
+             :test-encoding {:jvm-opts ["-Dfile.encoding=ANSI_X3.4-1968"]
+                             :test-selectors ^:replace {:default :encoding}}}
   :global-vars {*warn-on-reflection* true})

--- a/project.clj
+++ b/project.clj
@@ -27,9 +27,9 @@
   :plugins [[lein-codox "0.10.7"]
             [lein-pprint "1.3.2"]]
   :target-path "target/%s"
-  :test-selectors {:default (complement :integration)
+  :test-selectors {:default (every-pred (complement :integration) (complement :encoding))
                    :integration :integration
-                   :all (constantly true)}
+                   :all (complement :encoding)}
   :profiles {:uberjar {:aot :all
                        :pedantic? :abort}
              :dev {:dependencies
@@ -39,7 +39,7 @@
              :test {:dependencies
                     ~test-deps
                     :resource-paths ["test/resources"]
-                    :pedantic? :warn}
+                    :pedantic? :abort}
              :test-encoding {:jvm-opts ["-Dfile.encoding=ANSI_X3.4-1968"]
                              :test-selectors ^:replace {:default :encoding}}}
   :global-vars {*warn-on-reflection* true})

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
 (def test-deps
   `[[ring/ring-codec ~ring-version]])
 
-(defproject threatgrid/ductile "0.4.5"
+(defproject threatgrid/ductile "0.4.6-SNAPSHOT"
   :description "Yet another Clojure client for Elasticsearch REST API, that fits our needs"
   :url "https://github.com/threatgrid/ductile"
   :license {:name "Eclipse Public License"

--- a/src/ductile/document.clj
+++ b/src/ductile/document.clj
@@ -90,7 +90,7 @@
   "Count the size of the given string in bytes."
   [^String s]
   (when s
-    (count (.getBytes s))))
+    (count (.getBytes s "UTF-8"))))
 
 (defn format-bulk-doc-fn
   "helper to prepare a bulk operation"
@@ -136,7 +136,7 @@
 (defn string->input-stream
   [^String s]
   (-> s
-      (.getBytes)
+      (.getBytes "UTF-8")
       (ByteArrayInputStream.)))
 
 (defn ^:private bulk-post-docs

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -10,7 +10,8 @@
             [ring.util.codec :refer [form-decode]]
             [schema.test :refer [validate-schemas]])
   (:import clojure.lang.ExceptionInfo
-           [java.util UUID]))
+           [java.util UUID]
+           [java.io InputStream]))
 
 (use-fixtures :once validate-schemas)
 
@@ -859,7 +860,8 @@
 (deftest ^:encoding string->input-stream
   (testing "creates input stream containing UTF-8 representation of a string"
     (is (= (seq (.getBytes "qй" "UTF-8"))
-           (seq (loop [acc [] is (sut/string->input-stream "qй")]
+           (seq (loop [acc []
+                       ^InputStream is (sut/string->input-stream "qй")]
                   (let [b (.read is)]
                     (if (= -1 b)
                       acc

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -859,4 +859,8 @@
 (deftest ^:encoding string->input-stream
   (testing "creates input stream containing UTF-8 representation of a string"
     (is (= (seq (.getBytes "qй" "UTF-8"))
-           (seq (.readAllBytes (sut/string->input-stream "qй")))))))
+           (seq (loop [acc [] is (sut/string->input-stream "qй")]
+                  (let [b (.read is)]
+                    (if (= -1 b)
+                      acc
+                      (recur (conj acc (unchecked-byte b)) is)))))))))

--- a/test/ductile/document_test.clj
+++ b/test/ductile/document_test.clj
@@ -850,3 +850,13 @@
                                 es-params)
              (pagination-params es7-result
                                 es-params))))))
+
+(deftest ^:encoding byte-size-test
+  (testing "calculation of string byte size respect UTF-8 encoding"
+    (is (= (count (.getBytes "qй" "UTF-8"))
+           (sut/byte-size "qй")))))
+
+(deftest ^:encoding string->input-stream
+  (testing "creates input stream containing UTF-8 representation of a string"
+    (is (= (seq (.getBytes "qй" "UTF-8"))
+           (seq (.readAllBytes (sut/string->input-stream "qй")))))))


### PR DESCRIPTION
`getBytes` method without explicit encoding will use the global parameter `file.encoding` and in case it is set to something else than UTF-8 the payload might be not recognised at all by elasticksearch. Currently ES [support](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html) only UTF-8. The fix is to make UTF-8 encoding explicit for the process of preparing HTTP requests body parameter.